### PR TITLE
[#18] Fixed maint queries and inst id 0 for all workers

### DIFF
--- a/lib/main.go
+++ b/lib/main.go
@@ -158,7 +158,7 @@ func Run() {
 			os.Exit(13)
 		}
 	}
-	InitRacMaint()
+	InitRacMaint(*namePtr)
 
 	srv := NewServer(lsn, HandleConnection)
 

--- a/lib/workerpool.go
+++ b/lib/workerpool.go
@@ -681,7 +681,7 @@ func (pool *WorkerPool) RacMaint(racReq racAct) {
 	cnt := 0
 	pool.poolCond.L.Lock()
 	for i := 0; i < pool.currentSize; i++ {
-		if (pool.workers[i] != nil) && (pool.workers[i].racID == racReq.instID) && (pool.workers[i].startTime < int64(racReq.tm)) {
+		if (pool.workers[i] != nil) && (racReq.instID == 0 || pool.workers[i].racID == racReq.instID) && (pool.workers[i].startTime < int64(racReq.tm)) {
 			statusTime := now
 			// requested time is in the past, restart starts from now
 			// requested time is in the future, set restart time starting from it

--- a/tests/unittest/rac_maint/main_test.go
+++ b/tests/unittest/rac_maint/main_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.com/paypal/hera/tests/unittest/testutil"
+	"github.com/paypal/hera/utility/logger"
+	"os"
+	"testing"
+	"time"
+)
+
+var mx testutil.Mux
+var tableName string
+
+func cfg() (map[string]string, map[string]string, testutil.WorkerType) {
+
+	appcfg := make(map[string]string)
+	// best to chose an "unique" port in case golang runs tests in paralel
+	appcfg["bind_port"] = "31002"
+	appcfg["log_level"] = "5"
+	appcfg["log_file"] = "occ.log"
+	appcfg["sharding_cfg_reload_interval"] = "0"
+	appcfg["rac_sql_interval"] = "1"
+
+	opscfg := make(map[string]string)
+	opscfg["opscfg.default.server.max_connections"] = "3"
+	opscfg["opscfg.default.server.log_level"] = "5"
+
+	return appcfg, opscfg, testutil.MySQLWorker
+}
+
+func setupDb() error {
+	tableName = os.Getenv("TABLE_NAME")
+	if tableName == "" {
+		tableName = "occ_maint"
+	}
+
+	testutil.RunDML("DROP TABLE " + tableName)
+	return testutil.RunDML("CREATE TABLE " + tableName + " ( inst_id bigint, machine varchar(512), status varchar(8), status_time bigint, module varchar(64) )")
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.UtilMain(m, cfg, setupDb))
+}
+
+func TestRacMaint(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestRacMaint begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+
+	shard := 0
+	db, err := sql.Open("occloop", fmt.Sprintf("%d:0:0", shard))
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// cleanup and insert one row in the table
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	defer conn.Close()
+	tx, _ := conn.BeginTx(ctx, nil)
+	stmt, _ := tx.PrepareContext(ctx, "/*cmd*/delete from "+tableName)
+	_, err = stmt.Exec()
+	if err != nil {
+		t.Fatalf("Error preparing test (delete table) %s\n", err.Error())
+	}
+	stmt, _ = tx.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (inst_id, status, status_time, module, machine) values (?,?,?,?,?)")
+	hostname, _ := os.Hostname()
+	// how to do inst_id
+	_, err = stmt.Exec(15/*max instid*/, "F", time.Now().Unix()+2, "occ", hostname)
+	if err != nil {
+		t.Fatalf("Error preparing test (create row in table) %s\n", err.Error())
+	}
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error commit %s\n", err.Error())
+	}
+
+	time.Sleep(4100 * time.Millisecond)
+	if 0 != testutil.RegexCountFile("Rac maint activating, worker", "occ.log") {
+		t.Fatalf("should not have rac maint activation")
+	}
+
+	tx, err = conn.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("Error 2commit %s\n", err.Error())
+	}
+	delS, err := tx.PrepareContext(ctx, "/*cmd*/delete from "+tableName)
+	if err != nil {
+		t.Fatalf("Error prep del %s\n", err.Error())
+	}
+	delS.Exec()
+	insS, err := tx.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (inst_id, status, status_time, module, machine) values (?,?,?,?,?)")
+	if err != nil {
+		t.Fatalf("Error prep ins %s\n", err.Error())
+	}
+	// mysql uses instId 0 since there isn't instid's
+	insS.Exec(0, "F", time.Now().Unix()+1, "occ", hostname)
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error 2commit %s\n", err.Error())
+	}
+
+	time.Sleep(4100 * time.Millisecond)
+	if 0 == testutil.RegexCountFile("Rac maint activating, worker", "occ.log") {
+		t.Fatalf("missed rac maint activation")
+	}
+
+	logger.GetLogger().Log(logger.Debug, "TestRacMaint done  -------------------------------------------------------------")
+}

--- a/tests/unittest/testutil/util.go
+++ b/tests/unittest/testutil/util.go
@@ -1,12 +1,17 @@
 package testutil
 
 import (
+	"bufio"
 	"context"
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"regexp"
 	"time"
+
+	"github.com/paypal/hera/utility/logger"
 )
 
 var (
@@ -73,4 +78,40 @@ func RunDML(dml string) error {
 	}
 
 	return nil
+}
+
+func RegexCount(regex string) int {
+	return RegexCountFile(regex, "occ.log")
+}
+func RegexCountFile(regex string, filename string) int {
+	time.Sleep(10 * time.Millisecond)
+	fa, err := regexp.Compile(regex)
+	if err != nil {
+		logger.GetLogger().Log(logger.Debug, regex+"=regex err compile "+err.Error())
+		return -2
+	}
+	fh, err := os.Open(filename)
+	if err != nil {
+		logger.GetLogger().Log(logger.Debug, "could not open "+filename+" "+err.Error())
+		return -1
+	}
+	defer fh.Close()
+	scanner := bufio.NewScanner(fh)
+	count := 0
+	lineNum := 0
+	//fmt.Println("BEGIN searching "+regex)
+	for scanner.Scan() {
+		lineNum++
+		ln := scanner.Text()
+		loc := fa.FindStringIndex(ln)
+		if loc != nil { // found
+			//fmt.Printf("FOUND %d\n", lineNum)
+			count++
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		logger.GetLogger().Log(logger.Debug, "err scanning occ.log "+err.Error())
+	}
+	//fmt.Println("DONE searching "+regex)
+	return count
 }


### PR DESCRIPTION
The maintenance table queries had db-specific functions that are now removed.
There is not an integer for MySQL instance in a cluster, so 0 is now setup to
cover all workers.

