### PR TITLE
Configurable state log prefix

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -117,6 +117,7 @@ type Config struct {
 	// to use OpenSSL (for testing) or crypto/tls
 	UseOpenSSL bool
 
+	StateLogPrefix string
 	ManagementTablePrefix string
 	// RAC maint reload config interval
 	RacMaintReloadInterval int
@@ -366,6 +367,7 @@ func InitConfig() error {
 	gAppConfig.UseOpenSSL = cdb.GetOrDefaultBool("openssl", false)
 	gAppConfig.MuxPidFile = cdb.GetOrDefaultString("mux_pid_file", "mux.pid")
 
+	gAppConfig.StateLogPrefix = cdb.GetOrDefaultString("state_log_prefix", "hera")
 	gAppConfig.ManagementTablePrefix = cdb.GetOrDefaultString("management_table_prefix", "hera")
 	gAppConfig.RacMaintReloadInterval = cdb.GetOrDefaultInt("rac_sql_interval", 10)
 	gAppConfig.RacRestartWindow = cdb.GetOrDefaultInt("rac_restart_window", 240)

--- a/lib/statelog.go
+++ b/lib/statelog.go
@@ -51,8 +51,9 @@ const (
 var StateNames = [MaxWorkerState + MaxConnState]string{
 	"init", "acpt", "wait", "busy", "schd", "fnsh", "quce", "asgn", "idle", "bklg", "strd", "cls"}
 
+// These get a prefix added to them in init
 var typeTitlePrefix = [wtypeTotalCount]string{
-	"hera.w", "hera.r", "hera.taf"}
+	".w", ".r", ".taf"}
 
 // WorkerStateInfo is a container holding worker state information
 type WorkerStateInfo struct {
@@ -477,8 +478,11 @@ func (sl *StateLog) init() error {
 	}
 	sl.mStateHeader = buf.String()
 
+	for idx, val := range typeTitlePrefix {
+		typeTitlePrefix[idx] = GetConfig().StateLogPrefix + val
+	}
 	if GetConfig().ReadonlyPct == 0 {
-		typeTitlePrefix[wtypeRW] = "hera"
+		typeTitlePrefix[wtypeRW] = GetConfig().StateLogPrefix
 	}
 	for s := 0; s < sl.maxShardSize; s++ {
 		for t := wtypeRW; t < wtypeTotalCount; t++ {


### PR DESCRIPTION
For #29, like management_table_prefix, I add a config for state_log_prefix which is defaulted to "hera" and can be reconfigured if needed. 