### PR TITLE
[#20] Failover on Error 1290 read-only

### DIFF
--- a/worker/mysqlworker/adapter.go
+++ b/worker/mysqlworker/adapter.go
@@ -195,6 +195,7 @@ func (adapter *mysqlAdapter) ProcessError(errToProcess error, workerScope *share
 	case 1159: fallthrough // read timeout
 	case 1160: fallthrough // err write
 	case 1161: fallthrough // write timeout
+	case 1290: fallthrough // read-only mode
 	case 1317: fallthrough // query interupt
 	case 1836: fallthrough // read-only mode
 	case 1874: fallthrough // innodb read-only


### PR DESCRIPTION
It seems mysql DBs use error 1290 to indicate the server is read-only (used to indicate maintenance).  We'll need to recycle mysqlworker's that encounter that error.

Also revises tests to have check frequently after failover maintenance begins.  In the default setup, a few connections are lost as the failover begins.  But it seems to be back to normal on the 4th loop.