### PR TITLE
Adjust sql parser to allow both MySQL and Oracle transactions.

### DIFF
--- a/common/sqlParser.go
+++ b/common/sqlParser.go
@@ -28,6 +28,7 @@ import (
 type SQLParser interface {
 	IsRead(string) bool
 	Parse(sql string) (isSelect bool, transaction bool)
+	MustExecInsteadOfPrepare(sql string) (bool)
 }
 
 type regexSQLParser struct {
@@ -51,6 +52,10 @@ func NewRegexSQLParser() (SQLParser, error) {
 		return nil, err
 	}
 	return parser, nil
+}
+
+func (parser *regexSQLParser) MustExecInsteadOfPrepare(sql string) bool {
+	return false
 }
 
 // IsRead tells is the SQL is doing a read, basically a SELECT but not a SELECT ... FOR UPDATE or nextval
@@ -85,6 +90,10 @@ func NewDummyParser() SQLParser {
 	return &dummyParser{}
 }
 
+func (parser *dummyParser) MustExecInsteadOfPrepare(sql string) bool {
+	return false
+}
+
 func (parser *dummyParser) IsRead(sql string) bool {
 	return false
 }
@@ -92,3 +101,47 @@ func (parser *dummyParser) IsRead(sql string) bool {
 func (parser *dummyParser) Parse(sql string) (bool, bool) {
 	return false, false
 }
+
+type autoCommitParser struct {
+	matcher *regexp.Regexp
+	matcherBeginOrStartTransaction *regexp.Regexp
+}
+// NewDummyParser crestes a parser that always returns false
+func NewAutoCommitParser() (SQLParser, error) {
+	parser := &autoCommitParser{}
+	var err error
+	parser.matcherBeginOrStartTransaction, err = regexp.Compile("(?i)^\\s*(/\\*.*\\*/)*\\s*(start \\s*transaction|begin)")
+	if err != nil {
+		return nil, err
+	}
+	parser.matcher, err = regexp.Compile("(?i)^\\s*(/\\*.*\\*/)*\\s*select\\s+")
+	if err != nil {
+		return nil, err
+	}
+	return parser, nil
+}
+
+func (parser *autoCommitParser) MustExecInsteadOfPrepare(sql string) bool {
+	return parser.matcherBeginOrStartTransaction.MatchString(sql)
+}
+
+func (parser *autoCommitParser) IsRead(sql string) bool {
+	if parser.matcherBeginOrStartTransaction.MatchString(sql) {
+		return false
+	}
+	return true
+}
+
+// - first return code tells if the query is a SELECT
+// - second returns code tells the query starts a transaction
+// mysql-autocommit select..for update doesn't start a transaction
+func (parser *autoCommitParser) Parse(sql string) (bool, bool) {
+	isSelect := parser.matcher.MatchString(sql)
+	if parser.matcherBeginOrStartTransaction.MatchString(sql) {
+		return isSelect, true
+	}
+	return isSelect, false
+}
+
+
+

--- a/tests/unittest/coordinator_basic/main_test.go
+++ b/tests/unittest/coordinator_basic/main_test.go
@@ -78,7 +78,7 @@ func TestCoordinatorBasic(t *testing.T) {
 		t.Fatalf("Error getting connection %s\n", err.Error())
 	}
 	tx, _ := conn.BeginTx(ctx, nil)
-	stmt, _ := tx.PrepareContext(ctx, "/*cmd*/delete "+tableName)
+	stmt, _ := tx.PrepareContext(ctx, "/*cmd*/delete from "+tableName)
 	_, err = stmt.Exec()
 	if err != nil {
 		t.Fatalf("Error preparing test (delete table) %s\n", err.Error())

--- a/tests/unittest/mysql_autocommit/main_test.go
+++ b/tests/unittest/mysql_autocommit/main_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"github.paypal.com/AppDataServices/mux/tests/unittest/testutil"
+	"github.paypal.com/AppDataServices/mux/utility/logger"
+	"os"
+	"testing"
+	"time"
+)
+
+var mx testutil.Mux
+var tableName string
+
+func cfg() (map[string]string, map[string]string, testutil.WorkerType) {
+
+	appcfg := make(map[string]string)
+	// best to chose an "unique" port in case golang runs tests in paralel
+	appcfg["bind_port"] = "31002"
+	appcfg["log_level"] = "5"
+	appcfg["log_file"] = "occ.log"
+	appcfg["sharding_cfg_reload_interval"] = "0"
+	appcfg["rac_sql_interval"] = "0"
+
+	opscfg := make(map[string]string)
+	opscfg["opscfg.default.server.max_connections"] = "3"
+	opscfg["opscfg.default.server.log_level"] = "5"
+
+	return appcfg, opscfg, testutil.MySQLWorker
+}
+
+func setupDb() error {
+	tableName = os.Getenv("TABLE_NAME")
+	if tableName == "" {
+		tableName = "jdbc_mux_test"
+	}
+
+	testutil.RunDML("DROP TABLE " + tableName)
+	return testutil.RunDML("CREATE TABLE " + tableName + " ( id bigint, int_val bigint, str_val varchar(128) )")
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.UtilMain(m, cfg, setupDb))
+}
+
+func TestMysqlAutocommit(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestMysqlAutocommit begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+
+	shard := 0
+	db, err := sql.Open("occloop", fmt.Sprintf("%d:0:0", shard))
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// cleanup and insert one row in the table
+	conn2, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting conn2 %s\n", err.Error())
+	}
+	defer conn2.Close()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	defer conn.Close()
+	tx, _ := conn.BeginTx(ctx, nil)
+	stmt, _ := tx.PrepareContext(ctx, "/*cmd*/delete from "+tableName)
+	_, err = stmt.Exec()
+	if err != nil {
+		t.Fatalf("Error preparing test (delete table) %s\n", err.Error())
+	}
+	stmt, _ = tx.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (id, int_val, str_val) VALUES(?, ?, ?)")
+	_, err = stmt.Exec(1, time.Now().Unix(), "val 1")
+	if err != nil {
+		t.Fatalf("Error preparing test (create row in table) %s\n", err.Error())
+	}
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error commit %s\n", err.Error())
+	}
+
+	if getRows(1, conn) != 1 {
+		t.Fatalf("exp 1 row")
+	}
+
+	// autocommit should see the row in other conn immediately
+	stmt, _ = conn.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (id, int_val, str_val) VALUES(?, ?, ?)")
+	_, err = stmt.Exec(2, time.Now().Unix(), "val 2")
+	if err != nil {
+		t.Fatalf("Error preparing test (create row id2 in table) %s\n", err.Error())
+	}
+	if getRows(2, conn) != 1 {
+		t.Fatalf("exp 1 row id2")
+	}
+	if getRows(2, conn2) != 1 {
+		t.Fatalf("exp 1 row id2 conn2")
+	}
+
+	// in txn, other conn sees after commit
+	tx, _ = conn.BeginTx(ctx, nil)
+	_/*result*/, err = tx.ExecContext(ctx, "begin /* start transaction */")
+	if err != nil {
+		t.Fatalf("begin/start txn statement issue %s", err.Error())
+	}
+
+	stmt, _ = tx.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (id, int_val, str_val) VALUES(?, ?, ?)")
+	_, err = stmt.Exec(3, time.Now().Unix(), "val 3")
+	if err != nil {
+		t.Fatalf("Error preparing test (create row id3 in table) %s\n", err.Error())
+	}
+	if getRows(3, conn) != 1 {
+		t.Fatalf("exp 1 row id3")
+	}
+	if getRows(3, conn2) != 0 {
+		t.Fatalf("exp 0 row id3 conn2")
+	}
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error commit %s\n", err.Error())
+	}
+	if getRows(3, conn2) != 1 {
+		t.Fatalf("exp 3 row id2 conn2")
+	}
+
+	logger.GetLogger().Log(logger.Debug, "TestMysqlAutocommit done  -------------------------------------------------------------")
+}
+func getRows(id int, conn *sql.Conn) (int) {
+	out := 0
+	ctx, cancel := context.WithTimeout(context.Background(), 9*time.Second)
+	defer cancel()
+	stmt, _ := conn.PrepareContext(ctx, "/*cmd*/Select id, int_val from "+tableName+" where id=?")
+	rows, _ := stmt.Query(id)
+	for rows.Next() {
+		out++
+	}
+
+	rows.Close()
+	stmt.Close()
+	return out;
+}

--- a/tests/unittest/mysql_direct/main_test.go
+++ b/tests/unittest/mysql_direct/main_test.go
@@ -1,0 +1,162 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+    _ "github.com/go-sql-driver/mysql"
+	"github.com/paypal/hera/tests/unittest/testutil"
+	"github.com/paypal/hera/utility/logger"
+)
+
+var tableName string
+
+func cfg() (map[string]string, map[string]string, testutil.WorkerType) {
+
+	appcfg := make(map[string]string)
+	// best to chose an "unique" port in case golang runs tests in paralel
+	/*
+		appcfg["bind_port"] = "31002"
+		appcfg["log_level"] = "5"
+		appcfg["log_file"] = "occ.log"
+		appcfg["sharding_cfg_reload_interval"] = "0"
+		appcfg["rac_sql_interval"] = "0"
+		// */
+
+	opscfg := make(map[string]string)
+	/*
+		opscfg["opscfg.default.server.max_connections"] = "3"
+		opscfg["opscfg.default.server.log_level"] = "5"
+		// */
+
+	return appcfg, opscfg, testutil.MySQLWorker
+}
+
+func setupDb() error {
+	tableName = os.Getenv("TABLE_NAME")
+	if tableName == "" {
+		tableName = "jdbc_mux_test"
+	}
+
+	//testutil.RunDML("DROP TABLE " + tableName)
+	//return testutil.RunDML("CREATE TABLE " + tableName + " ( id bigint, int_val bigint, str_val varchar(128) )")
+	return nil
+}
+
+/*
+func TestMain(m *testing.M) {
+	os.Exit(testutil.UtilMain(m, cfg, setupDb))
+}
+// */
+
+func TestMysqlAutocommit(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestMysqlAutocommit begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+	setupDb()
+
+	/* shard := 0
+	db, err := sql.Open("occloop", fmt.Sprintf("%d:0:0", shard)) // */
+
+	// not using worker env's "username" "password"
+	fullDsn:=fmt.Sprintf("%s:%s@%s", os.Getenv("DB_USER"), os.Getenv("DB_PASSWORD"), os.Getenv("DB_DATASOURCE"))
+	fmt.Println("fullDsn",fullDsn)
+	db, err := sql.Open("mysql", fullDsn)
+	if err != nil {
+		t.Fatal("Error starting direct mysql:", err)
+		return
+	}
+	db.SetMaxIdleConns(2)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	// cleanup and insert one row in the table
+	conn2, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting conn2 %s\n", err.Error())
+	}
+	defer conn2.Close()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	defer conn.Close()
+	tx, _ := conn.BeginTx(ctx, nil)
+	stmt, _ := tx.PrepareContext(ctx, "/*cmd*/delete from "+tableName)
+	_, err = stmt.Exec()
+	if err != nil {
+		t.Fatalf("Error preparing test (delete table) %s\n", err.Error())
+	}
+	stmt, _ = tx.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (id, int_val, str_val) VALUES(?, ?, ?)")
+	_, err = stmt.Exec(1, time.Now().Unix(), "val 1")
+	if err != nil {
+		t.Fatalf("Error preparing test (create row in table) %s\n", err.Error())
+	}
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error commit %s\n", err.Error())
+	}
+
+	if getRows(1, conn) != 1 {
+		t.Fatalf("exp 1 row")
+	}
+
+	// autocommit should see the row in other conn immediately
+	stmt, _ = conn.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (id, int_val, str_val) VALUES(?, ?, ?)")
+	_, err = stmt.Exec(2, time.Now().Unix(), "val 2")
+	if err != nil {
+		t.Fatalf("Error preparing test (create row id2 in table) %s\n", err.Error())
+	}
+	if getRows(2, conn) != 1 {
+		t.Fatalf("exp 1 row id2")
+	}
+	if getRows(2, conn2) != 1 {
+		t.Fatalf("exp 1 row id2 conn2")
+	}
+
+	// in txn, other conn sees after commit
+	tx, _ = conn.BeginTx(ctx, nil) // this sends "start transaction"
+	// testing double "start transaction"
+	_, err = tx.ExecContext(ctx, "begin") // ignore result 
+	if err != nil {
+		t.Fatalf("begin/start txn statement issue %s", err.Error())
+	} 
+
+	stmt, _ = tx.PrepareContext(ctx, "/*cmd*/insert into "+tableName+" (id, int_val, str_val) VALUES(?, ?, ?)")
+	_, err = stmt.Exec(3, time.Now().Unix(), "val 3")
+	if err != nil {
+		t.Fatalf("Error preparing test (create row id3 in table) %s\n", err.Error())
+	}
+	if getRows(3, conn) != 1 {
+		t.Fatalf("exp 1 row id3")
+	}
+	if getRows(3, conn2) != 0 {
+		t.Fatalf("exp 0 row id3 conn2")
+	}
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error commit %s\n", err.Error())
+	}
+	if getRows(3, conn2) != 1 {
+		t.Fatalf("exp 3 row id2 conn2")
+	}
+
+	logger.GetLogger().Log(logger.Debug, "TestMysqlAutocommit done  -------------------------------------------------------------")
+}
+func getRows(id int, conn *sql.Conn) int {
+	out := 0
+	ctx, cancel := context.WithTimeout(context.Background(), 9*time.Second)
+	defer cancel()
+	stmt, _ := conn.PrepareContext(ctx, "/*cmd*/Select id, int_val from "+tableName+" where id=?")
+	rows, _ := stmt.Query(id)
+	for rows.Next() {
+		out++
+	}
+
+	rows.Close()
+	stmt.Close()
+	return out
+}

--- a/tests/unittest/testutil/setup.go
+++ b/tests/unittest/testutil/setup.go
@@ -85,6 +85,9 @@ func (m *mux) setupConfig() error {
 	// opscfg
 	m.appcfg["opscfg.hera.server.max_connections"] = m.opscfg["opscfg.default.server.max_connections"]
 	m.appcfg["opscfg.hera.server.log_level"] = m.opscfg["opscfg.default.server.log_level"]
+	if m.wType != OracleWorker {
+		m.appcfg["child.executable"] = "mysqlworker"
+	}
 	err := createCfg(m.appcfg, "hera")
 	if err != nil {
 		return err

--- a/worker/mysqlworker/adapter.go
+++ b/worker/mysqlworker/adapter.go
@@ -36,7 +36,7 @@ type mysqlAdapter struct {
 }
 
 func (adapter *mysqlAdapter) MakeSqlParser() (common.SQLParser ,error) {
-	return common.NewAutoCommitParser()
+	return common.NewRegexSQLParser()
 }
 
 // InitDB creates sql.DB object for conection to the mysql database, using "username", "password" and

--- a/worker/mysqlworker/adapter.go
+++ b/worker/mysqlworker/adapter.go
@@ -27,11 +27,16 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/paypal/hera/common"
 	"github.com/paypal/hera/utility/logger"
 	"github.com/paypal/hera/worker/shared"
 )
 
 type mysqlAdapter struct {
+}
+
+func (adapter *mysqlAdapter) MakeSqlParser() (common.SQLParser ,error) {
+	return common.NewAutoCommitParser()
 }
 
 // InitDB creates sql.DB object for conection to the mysql database, using "username", "password" and

--- a/worker/oracleworker/adapter.go
+++ b/worker/oracleworker/adapter.go
@@ -27,9 +27,14 @@ import (
 	_ "gopkg.in/goracle.v2"
 	"github.com/paypal/hera/utility/logger"
 	"github.com/paypal/hera/worker/shared"
+	"github.com/paypal/hera/common"
 )
 
 type oracleAdapter struct {
+}
+
+func (adapter *oracleAdapter) MakeSqlParser() (common.SQLParser, error) {
+	return common.NewRegexSQLParser()
 }
 
 // InitDB creates sql.DB object for conection to the database, using "username", "password" and "TWO_TASK" environment


### PR DESCRIPTION
This code now does both "start transaction" (MySQL-style) and implicit transactions (Oracle-style).  We continue to expect Hera JDBC driver to do the client-side autocommit.

The prior work for mysql "start transaction" is being rolled forward.  One of the Java tests was using Oracle-style transactions.  The hera worker uses the mysql driver's BeginTx() which starts a DB transaction.  That's why it worked originally.

The first merge of the "start transaction" code had a new parser which wanted to move everything to the MySQL style of using "start transaction" instead of Oracle's implicit transaction starts.

We've checked that the test which broke now passes.