### PR TITLE
[#96] signal in timeout case to avoid goroutine leak

### DIFF
--- a/lib/workerpool.go
+++ b/lib/workerpool.go
@@ -357,10 +357,9 @@ func (pool *WorkerPool) GetWorker(sqlhash int32, timeoutMs ...int) (worker *Work
 				logger.GetLogger().Log(logger.Debug, "backlog timeout. type:", pool.Type, ", instance:", pool.InstID)
 			}
 			//
-			// we are bailing out. but the waiting routine is still sleeping. a notify
-			// later is going to eventually wake that up. the sleeping routine writes
-			// to noone and release the lock. no resource deadlock or leaking.
+			// we are bailing out. but the waiting routine is still sleeping.
 			//
+			pool.poolCond.Signal() // try to jostle the waiting routine free
 			if longTo {
 				return nil, "", ErrBklgTimeout
 			}

--- a/tests/unittest/mysql_autocommit/main_test.go
+++ b/tests/unittest/mysql_autocommit/main_test.go
@@ -107,7 +107,7 @@ func TestMysqlAutocommit(t *testing.T) {
 
 	// in txn, other conn sees after commit
 	tx, _ = conn.BeginTx(ctx, nil)
-	_/*result*/, err = tx.ExecContext(ctx, "begin /* start transaction */")
+	_/*result*/, err = tx.ExecContext(ctx, "start transaction")
 	if err != nil {
 		t.Fatalf("begin/start txn statement issue %s", err.Error())
 	}


### PR DESCRIPTION
I used a separate client to lock a row.  Then, a few clients did select-for-update to use all the mysqlworker connections.  This causes backlogs which trigger the leak.