### PR TITLE
[#125] allowing override of module name with env LOG_DB_HOST_NAME

### DIFF
--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -194,15 +194,21 @@ func NewWorker(wid int, wType HeraWorkerType, instID int, shardID int, moduleNam
 func (worker *WorkerClient) StartWorker() (err error) {
 	attr := syscall.ProcAttr{Dir: "./", Env: os.Environ(), Files: nil, Sys: nil}
 	var dbHostName string
-	if len(worker.moduleName) > 4 {
-		dbHostName = strings.ToUpper(worker.moduleName[4:])
-		pos := strings.Index(dbHostName, "-")
-		if pos != -1 {
-			dbHostName = dbHostName[:pos]
-		}
+	logDbHostName := os.Getenv("LOG_DB_HOST_NAME")
+	if len(logDbHostName) > 0 {
+		dbHostName = logDbHostName
 	} else {
-		return errors.New("Invalid module name, must be like hera-<name> ")
+		if len(worker.moduleName) > 4 {
+			dbHostName = strings.ToUpper(worker.moduleName[4:])
+			pos := strings.Index(dbHostName, "-")
+			if pos != -1 {
+				dbHostName = dbHostName[:pos]
+			}
+		} else {
+			return errors.New("Invalid module name, must be like hera-<name> ")
+		}
 	}
+
 
 	var twoTask string
 	switch worker.Type {


### PR DESCRIPTION
I thought about using TWO_TASK, but in multi-instance test environments and multiple shards and read-write split, it gets too tangled.