### PR TITLE
[#132] Use :scuttle_id to block sql rewrite

### DIFF
--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -65,6 +65,9 @@ where r.subordinate_id = e.id and e.id = :employee_id_sk
 *SQL Update to Shard Key*
 Updating of a shard key will initially work, but it will likely be in the wrong shard after the update. This is not detected by Hera.
 
+*Subquery*
+The cpp oracleworker rewrite mechanism is barely aware of subqueries. Please keep your WHERE conditions closer to the actual tables.
+
 Other Unsupported Operations
 * Queries by ROWID will not be supported – When you switch shards, the ROWID no longer applies.
 Sequences are not supported – This is not detected by Hera. Each separate shard of the DB would return its own sequence and might collide.

--- a/worker/cppworker/worker/SQLRewriter.cpp
+++ b/worker/cppworker/worker/SQLRewriter.cpp
@@ -63,6 +63,9 @@ void SQLRewriter::init(const std::string& _shard_key_name, const std::string& _s
 	os.str("");
 	os << ", :" << m_sSCUTTLE_NAME;
 	m_sCOMMA_SCUTTLE_ID = os.str();
+	os.str("");
+	os << ":" << m_sSCUTTLE_NAME;
+	m_sCOLON_SCUTTLE_ID = os.str();
 	
 	
 	m_shard_key_name = _shard_key_name;
@@ -169,7 +172,7 @@ SQLRewriter::SqlType SQLRewriter::get_type(const std::string& _sql) {
 }
 
 bool SQLRewriter::has_scuttle_id(const std::string& _sql) {
-	return (0 != strcasestr(_sql.c_str(), m_sSCUTTLE_NAME.c_str()));
+	return (0 != strcasestr(_sql.c_str(), m_sCOLON_SCUTTLE_ID.c_str()));
 }
 
 void SQLRewriter::rewrite_select(const std::string& _sql)

--- a/worker/cppworker/worker/SQLRewriter.cpp
+++ b/worker/cppworker/worker/SQLRewriter.cpp
@@ -336,21 +336,7 @@ void SQLRewriter::rewrite_select(const std::string& _sql)
 						val.sql.append(m_sDOT_SCUTTLE_ID.c_str(), m_sDOT_SCUTTLE_ID.length()); //".scuttle_id"
 						break;
 					}
-					case 0: // select
-						if (inner_select) {
-							int alias_len = 0;
-							const char *alias = 0;
-							get_alias(start, next - m_shard_key_name.length(), alias, alias_len);
-							val.sql.append(start, next - start);
-							val.sql.append(sCOMMA.c_str(), sCOMMA.length()); // ", "
-							if (alias) {
-								val.sql.append(alias, alias_len + 1); // alias + "."
-							}
-							val.sql.append(m_sSCUTTLE_ID.c_str(), m_sSCUTTLE_ID.length()); // "scuttle_id"
-						} else {
-							val.sql.append(start, next - start);
-						}
-						break;
+					case 0: // select // fall thru, needs overhaul for inner select
 					default:
 						val.sql.append(start, next - start);
 						break;

--- a/worker/cppworker/worker/SQLRewriter.h
+++ b/worker/cppworker/worker/SQLRewriter.h
@@ -68,6 +68,7 @@ private:
 	std::string m_sDOT_SCUTTLE_ID;
 	std::string m_sSCUTTLE_ID;
 	std::string m_sCOMMA_SCUTTLE_ID;
+	std::string m_sCOLON_SCUTTLE_ID;
 
 	Finder m_query_type_finder, m_select_finder;
 


### PR DESCRIPTION
This is clean against our set of SQLs and should be able to rollout smoothly.