### PR TITLE
Throttle DB Connects

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -151,6 +151,9 @@ type Config struct {
 	EnableDanglingWorkerRecovery bool
 
 	GoStatsInterval int
+
+	// The max number of database connections to be established per second
+	MaxDbConnectsPerSec int
 }
 
 // The OpsConfig contains the configuration that can be modified during run time
@@ -405,6 +408,11 @@ func InitConfig() error {
 	gAppConfig.EnableDanglingWorkerRecovery = cdb.GetOrDefaultBool("enable_danglingworker_recovery", false)
 
 	gAppConfig.GoStatsInterval = cdb.GetOrDefaultInt("go_stats_interval", 10)
+	defaultConns := 10000 // disable by default
+	if gAppConfig.EnableTAF {
+		defaultConns = 5
+	}
+	gAppConfig.MaxDbConnectsPerSec = cdb.GetOrDefaultInt("max_db_connects_per_sec", defaultConns)
 
 	return nil
 }

--- a/lib/queue_test.go
+++ b/lib/queue_test.go
@@ -13,9 +13,9 @@ const (
 func TestDempotency(t *testing.T) {
 	gOpsConfig = &OpsConfig{numWorkers: 10}
 	var queue = NewQueue()
-	wa := NewWorker(0, wtypeRW, 0, 0, "cloc")
-	wb := NewWorker(0, wtypeRW, 0, 0, "cloc")
-	wc := NewWorker(0, wtypeRW, 0, 0, "cloc")
+	wa := NewWorker(0, wtypeRW, 0, 0, "cloc", nil)
+	wb := NewWorker(0, wtypeRW, 0, 0, "cloc", nil)
+	wc := NewWorker(0, wtypeRW, 0, 0, "cloc", nil)
 
 	queue.Push(wa) // wa
 	if queue.Len() != 1 {

--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -146,6 +146,9 @@ type WorkerClient struct {
 	// under recovery. 0: no; 1: yes. use atomic.CompareAndSwapInt32 to check state.
 	//
 	isUnderRecovery int32
+
+	// Throtle workers lifecycle
+	thr Throttler
 }
 
 type strandedCalInfo struct {
@@ -172,8 +175,8 @@ func envUpsert(attr *syscall.ProcAttr, key string, val string) {
 }
 
 // NewWorker creates a new workerclient instance (pointer)
-func NewWorker(wid int, wType HeraWorkerType, instID int, shardID int, moduleName string) *WorkerClient {
-	worker := &WorkerClient{ID: wid, Type: wType, Status: wsUnset, instID: instID, shardID: shardID, moduleName: moduleName}
+func NewWorker(wid int, wType HeraWorkerType, instID int, shardID int, moduleName string, thr Throttler) *WorkerClient {
+	worker := &WorkerClient{ID: wid, Type: wType, Status: wsUnset, instID: instID, shardID: shardID, moduleName: moduleName, thr: thr}
 	maxReqs := GetMaxRequestsPerChild()
 	if maxReqs >= 4 {
 		worker.maxReqCount = maxReqs - uint32(rand.Intn(int(maxReqs/4)))

--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -608,6 +608,7 @@ func (worker *WorkerClient) Recover(p *WorkerPool, ticket string, info *stranded
 	for {
 		select {
 		case <-workerRecoverTimeout:
+			worker.thr.CanRun()
 			worker.setState(wsInit) // Set the worker state to INIT when we decide to Terminate the worker
 			worker.Terminate()
 			worker.callogStranded("RECYCLED", info)

--- a/lib/workerpool.go
+++ b/lib/workerpool.go
@@ -82,6 +82,8 @@ type WorkerPool struct {
 
 	// the actual list of workers
 	workers []*WorkerClient
+	// Throtle workers lifecycle
+	thr Throttler
 }
 
 // Init creates the pool by creating the workers and making all the initializations
@@ -97,6 +99,7 @@ func (pool *WorkerPool) Init(wType HeraWorkerType, size int, instID int, shardID
 	pool.desiredSize = size
 	pool.moduleName = moduleName
 	pool.workers = make([]*WorkerClient, size)
+	pool.thr = NewThrottler(uint32(GetConfig().MaxDbConnectsPerSec), fmt.Sprintf("%d_%d_%d", wType, shardID, instID))
 	for i := 0; i < size; i++ {
 		err := pool.spawnWorker(i)
 		if err != nil {
@@ -113,7 +116,7 @@ func (pool *WorkerPool) Init(wType HeraWorkerType, size int, instID int, shardID
 
 // spawnWorker starts a worker and spawn a routine waiting for the "ready" message
 func (pool *WorkerPool) spawnWorker(wid int) error {
-	worker := NewWorker(wid, pool.Type, pool.InstID, pool.ShardID, pool.moduleName)
+	worker := NewWorker(wid, pool.Type, pool.InstID, pool.ShardID, pool.moduleName, pool.thr)
 	er := worker.StartWorker()
 	if er != nil {
 		if logger.GetLogger().V(logger.Alert) {
@@ -611,7 +614,7 @@ func (pool *WorkerPool) Resize(newSize int) {
 		//
 		GetStateLog().PublishStateEvent(StateEvent{eType: WorkerResizeEvt, shardID: pool.ShardID, wType: pool.Type, instID: pool.InstID, newWSize: newSize})
 		for i := pool.currentSize; i < newSize; i++ {
-			worker := NewWorker(i, pool.Type, pool.InstID, pool.ShardID, pool.moduleName)
+			worker := NewWorker(i, pool.Type, pool.InstID, pool.ShardID, pool.moduleName, pool.thr)
 			er := worker.StartWorker()
 			if er != nil {
 				if logger.GetLogger().V(logger.Alert) {

--- a/lib/workerpool_test.go
+++ b/lib/workerpool_test.go
@@ -68,12 +68,12 @@ func TestPoolDempotency(t *testing.T) {
 	}
 	go pool.checkWorkerLifespan()
 
-	wa := NewWorker(0, wtypeRW, 0, 0, "cloc")
-	wb := NewWorker(1, wtypeRW, 0, 0, "cloc")
-	wc := NewWorker(2, wtypeRW, 0, 0, "cloc")
-	wd := NewWorker(3, wtypeRW, 0, 0, "cloc")
-	we := NewWorker(4, wtypeRW, 0, 0, "cloc")
-	wf := NewWorker(5, wtypeRW, 0, 0, "cloc")
+	wa := NewWorker(0, wtypeRW, 0, 0, "cloc", nil)
+	wb := NewWorker(1, wtypeRW, 0, 0, "cloc", nil)
+	wc := NewWorker(2, wtypeRW, 0, 0, "cloc", nil)
+	wd := NewWorker(3, wtypeRW, 0, 0, "cloc", nil)
+	we := NewWorker(4, wtypeRW, 0, 0, "cloc", nil)
+	wf := NewWorker(5, wtypeRW, 0, 0, "cloc", nil)
 	wa.setState(wsAcpt)
 	wb.setState(wsAcpt)
 	wc.setState(wsAcpt)


### PR DESCRIPTION
When we use 100ms TAF timeout, the rate of DB connects can be high. This patch throttles those connects to keep the DB load better.