### PR TITLE
speeding up worker to avoid EOR_FREE_AGAIN

### DIFF
--- a/worker/cppworker/README.md
+++ b/worker/cppworker/README.md
@@ -4,4 +4,3 @@ This builds the Oracle worker for Hera (https://github.com/paypal/hera) in C++ f
 
 To build use build/makefile. The only dependencies needed are boost_regex devel package and the Oracle instant client 11 or 19.
 
-

--- a/worker/cppworker/build/makefile
+++ b/worker/cppworker/build/makefile
@@ -20,7 +20,7 @@ cppsrc = $(wildcard ../utility/encoding/*.cpp) $(wildcard ../utility/*.cpp) $(wi
 obj = $(csrc:.c=.o) $(cppsrc:.cpp=.o) 
 dep = $(obj:.o=.d)
 
-DEBUGFLAGS=-g
+DEBUGFLAGS=-g -O2
 ORACLE_HOME=/opt/instantclient_11_2/
 CPPFLAGS=-std=c++11 -I../ -I$(ORACLE_HOME)/sdk/include $(DEBUGFLAGS)
 CFLAGS=$(DEBUGFLAGS)

--- a/worker/cppworker/build/makefile19
+++ b/worker/cppworker/build/makefile19
@@ -20,7 +20,7 @@ cppsrc = $(wildcard ../utility/encoding/*.cpp) $(wildcard ../utility/*.cpp) $(wi
 obj = $(csrc:.c=.o) $(cppsrc:.cpp=.o) 
 dep = $(obj:.o=.d)
 
-DEBUGFLAGS=-g
+DEBUGFLAGS=-g -O2
 ORACLE_HOME=/opt/instantclient_19_3/
 CPPFLAGS=-std=c++11 -I../ -I$(ORACLE_HOME)/sdk/include $(DEBUGFLAGS)
 CFLAGS=$(DEBUGFLAGS)

--- a/worker/cppworker/worker/Worker.cpp
+++ b/worker/cppworker/worker/Worker.cpp
@@ -472,7 +472,7 @@ void Worker::run()
 			break;
 		}
 		
-		check_buffer();
+		//check_buffer();
 		if (!dedicated)
 		{
 			end_session();


### PR DESCRIPTION
The check_buffers() is from 2013 and a different architecture.