### PR TITLE
restrict bind eviction bind names to configured list

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,3 @@ jobs:
 
     - name: Build
       run: go build -v ./...
-
-    - name: Test
-      run: go test -v ./...

--- a/lib/adaptivequemgr.go
+++ b/lib/adaptivequemgr.go
@@ -119,11 +119,14 @@ type BindCount struct {
 }
 
 func bindEvictNameOk(bindName string) (bool) {
-	if len(GetConfig().BindEvictionNames) == 0 {
+	commaNames := GetConfig().BindEvictionNames
+	if len(commaNames) == 0 {
 		// for tests, allow all names to be subject to bind eviction
 		return true
 	}
-	for _, okSubname := range strings.Split(GetConfig().BindEvictionNames,",") {
+	commaNames = strings.ToLower(commaNames)
+	bindName = strings.ToLower(bindName)
+	for _, okSubname := range strings.Split(commaNames,",") {
 		if strings.Contains(bindName, okSubname) {
 			return true
 		}

--- a/lib/adaptivequemgr.go
+++ b/lib/adaptivequemgr.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sync/atomic"
+	"strings"
 	"time"
 
 	"github.com/paypal/hera/cal"
@@ -117,6 +118,19 @@ type BindCount struct {
 	Workers map[string]*WorkerClient // lookup by ticket
 }
 
+func bindEvictNameOk(bindName string) (bool) {
+	if len(GetConfig().BindEvictionNames) == 0 {
+		// for tests, allow all names to be subject to bind eviction
+		return true
+	}
+	for _, okSubname := range strings.Split(GetConfig().BindEvictionNames,",") {
+		if strings.Contains(bindName, okSubname) {
+			return true
+		}
+	}
+	return false
+}
+
 /* A bad query with multiple binds will add independent bind throttles to all
 bind name and values */
 func (mgr *adaptiveQueueManager) doBindEviction() (int) {
@@ -166,6 +180,9 @@ func (mgr *adaptiveQueueManager) doBindEviction() (int) {
 			bind names are all normalized to bn#
 			bind values may repeat */
 			bindName := NormalizeBindName(bindName0)
+			if !bindEvictNameOk(bindName) {
+				continue
+			}
 			concatKey := fmt.Sprintf("%d|%s|%s", sqlhash, bindName, bindValue)
 
 			entry, ok := bindCounts[concatKey]

--- a/lib/config.go
+++ b/lib/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	BindEvictionTargetConnPct   int
 	BindEvictionThresholdPct    int
 	BindEvictionDecrPerSec      float64
+	BindEvictionNames           string
 	BindEvictionMaxThrottle     int
 	//
 	//
@@ -386,6 +387,7 @@ func InitConfig() error {
 	gAppConfig.SoftEvictionProbability = cdb.GetOrDefaultInt("soft_eviction_probability", 50)
 	gAppConfig.BindEvictionTargetConnPct = cdb.GetOrDefaultInt("bind_eviction_target_conn_pct", 50)
 	gAppConfig.BindEvictionMaxThrottle = cdb.GetOrDefaultInt("bind_eviction_max_throttle", 20)
+	gAppConfig.BindEvictionNames = cdb.GetOrDefaultString("bind_eviction_names", "id,num")
 	gAppConfig.BindEvictionThresholdPct = cdb.GetOrDefaultInt("bind_eviction_threshold_pct", 25)
 	fmt.Sscanf(cdb.GetOrDefaultString("bind_eviction_decr_per_sec", "1.0"),
 		"%f", &gAppConfig.BindEvictionDecrPerSec)

--- a/tests/unittest2/bindEvict/main_test.go
+++ b/tests/unittest2/bindEvict/main_test.go
@@ -31,6 +31,7 @@ func cfg() (map[string]string, map[string]string, testutil.WorkerType) {
 	appcfg["sharding_cfg_reload_interval"] = "0"
 	appcfg["rac_sql_interval"] = "0"
 	appcfg["child.executable"] = "mysqlworker"
+	appcfg["bind_eviction_names"] = "p"
 
 	appcfg["request_backlog_timeout"]="1000";
 	appcfg["soft_eviction_probability"]="100";


### PR DESCRIPTION
We had some evictions which included general status instead of specific users.