### PR TITLE
scuttle_id array binds

### DIFF
--- a/client/java/jdbc/src/test/java/com/paypal/hera/jdbc/BatchTest.java
+++ b/client/java/jdbc/src/test/java/com/paypal/hera/jdbc/BatchTest.java
@@ -92,6 +92,7 @@ public class BatchTest {
 		table = System.getProperty("TABLE_NAME", "jdbc_hera_test"); 
 		HeraClientConfigHolder.clear();
 		Properties props = new Properties();
+		props.setProperty("hera.enable.batch", "true");
 		props.setProperty(HeraClientConfigHolder.RESPONSE_TIMEOUT_MS_PROPERTY, "3000");
 		props.setProperty(HeraClientConfigHolder.SUPPORT_RS_METADATA_PROPERTY, "true");
 		props.setProperty(HeraClientConfigHolder.SUPPORT_COLUMN_INFO_PROPERTY, "true");


### PR DESCRIPTION
When we try array binds (JDBC addBatch), we get a bind num mismatch since scuttle id rewrites don't match the number of array bind. 

This code adds the array bind for the added scuttle_id.