### PR TITLE
[#182] fixing rewritten scuttle_id array bind

### DIFF
--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -904,6 +904,7 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 			
 			uint sklen = m_shard_key_name.length();
 			if (0 == strncasecmp(bind_var_name, m_shard_key_name.c_str(), sklen)) {
+
 				// extra check, to accept names like party_id_0
 				if ((bind_var_name[sklen] == 0) || (strncmp(bind_var_name + sklen, "_0", 2) == 0)) {
 
@@ -916,25 +917,26 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 						if (logfile->get_log_level() >= LOG_VERBOSE)
 							WRITE_LOG_ENTRY(logfile, LOG_VERBOSE, "m_scuttle_id null in sql rewrite to mirror null shard key value");
 					} else {
-						unsigned long long scuttle_id_val = StringUtil::to_ullong(bind_values);
-						StringUtil::fmt_ulong(bind_values, compute_scuttle_id(scuttle_id_val));
-						bind_value_max_size = bind_values.length();
+						std::string scuttle_id_str_val;
+						StringUtil::fmt_ulong(scuttle_id_str_val, compute_scuttle_id(StringUtil::to_ullong(bind_values)));
+						bind_value_max_size = scuttle_id_str_val.length();
 
 						if (m_scuttle_id.empty()){
-							m_scuttle_id = bind_values;
+							m_scuttle_id = scuttle_id_str_val;
 							if (logfile->get_log_level() >= LOG_VERBOSE)
 								WRITE_LOG_ENTRY(logfile, LOG_VERBOSE, "m_scuttle_id %s in sql rewrite bindArrayMultiple:%d", m_scuttle_id.c_str(), bind_num);
 						}
 	
 						type = OCC_TYPE_STRING;
-						bind_value = bind_values;
-						bind_value_size[0] = bind_value.length();
+						bind_values.clear();
+						bind_values.append(scuttle_id_str_val);
+						bind_value_size[0] = scuttle_id_str_val.length();
 						for (int i=1; i<bind_num; i++) {
 							bind_values.append("\0", 1);
-							//scuttle id is same//bind_values.resize((i+1)*(bind_value_max_size+1));
-							bind_values.append(bind_value);
-							bind_value_size[i+1] = bind_value.length();
+							bind_values.append(scuttle_id_str_val);
+							bind_value_size[i] = bind_value_max_size;
 						}
+
 						bind(scuttle_id, bind_values, bind_value_size, bind_value_max_size, bind_num, (DataType)type);
 					} // non-null
 				}


### PR DESCRIPTION
Improved variable names.

The underlying errors were ORA-01722 number format. The bind value sizes were incorrect.