### PR TITLE
Basic postgresworker

### DIFF
--- a/worker/oracleworker/adapter.go
+++ b/worker/oracleworker/adapter.go
@@ -59,6 +59,9 @@ func (adapter *oracleAdapter) InitDB() (*sql.DB, error) {
 func (adapter *oracleAdapter) UseBindNames() bool {
 	return true
 }
+func (adapter *oracleAdapter) UseBindQuestionMark() bool {
+	return true
+}
 
 /**
  * @TODO

--- a/worker/postgresworker/main.go
+++ b/worker/postgresworker/main.go
@@ -1,0 +1,28 @@
+// Copyright 2021 PayPal Inc.
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Builds the postgres worker
+package main
+
+import (
+	workerservice "github.com/paypal/hera/worker/shared"
+)
+
+func main() {
+	workerservice.Start(&postgresAdapter{})
+}
+


### PR DESCRIPTION
This basic postgresworker code should allow queries with binds.

To use it, configure child.executable=postgresworker in hera.txt .

More work and research is needed for sharding, tls, query interrupt, and array binds. The team may wish to merge this early code and have more contributors work the other areas with parallel development and coordination.