### PR TITLE
cfg from tns for postgres/mysql

### DIFF
--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -362,7 +362,18 @@ func (worker *WorkerClient) StartWorker() (err error) {
 	}
 	envUpsert(&attr, "password2", dbPassword2)
 	envUpsert(&attr, "password3", dbPassword3)
-	envUpsert(&attr, "mysql_datasource", twoTask)
+	if twoTask[0] >= 'A' && twoTask[0] <= 'Z' {
+		tnsnames, err := FindTns()
+		dsn, ok := tnsnames[twoTask]
+		if err == nil && ok {
+			envUpsert(&attr, "mysql_datasource", dsn)
+			logger.GetLogger().Log(logger.Debug, "looked up mysql "+twoTask+" in tnsnames "+dsn)
+		} else {
+			logger.GetLogger().Log(logger.Alert, "could not lookup mysql "+twoTask+" in tnsnames")
+		}
+	} else {
+		envUpsert(&attr, "mysql_datasource", twoTask)
+	}
 
 	socketPair, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM, 0)
 	if err != nil {


### PR DESCRIPTION
Using a tnsnames.ora type file can help to manage multiple postgres and mysql endpoints, particularly with multiple environments.

This doesn't switch child.executable based on the tnsnames.ora. We can look at that in the future.