### PR TITLE
autosetting if not already set

### DIFF
--- a/lib/cfgFromTns.go
+++ b/lib/cfgFromTns.go
@@ -113,7 +113,7 @@ func CfgFromTns(name string) {
 
 		dbName = baseName+twoTaskSuffix
 		_,ok = tnsEntries[dbName]
-		if ok {
+		if ok || "" == os.Getenv("TWO_TASK") {
 			logErr("setting TWO_TASK "+dbName)
 			os.Setenv("TWO_TASK", dbName)
 		}


### PR DESCRIPTION
TWO_TASK can be automatically set, regardless of tnsnames configuration. This allows the service to start in dev while the other config is being worked on.