### PR TITLE
rewording log message

### DIFF
--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -362,17 +362,18 @@ func (worker *WorkerClient) StartWorker() (err error) {
 	}
 	envUpsert(&attr, "password2", dbPassword2)
 	envUpsert(&attr, "password3", dbPassword3)
+	envUpsert(&attr, "mysql_datasource", twoTask)
 	if twoTask[0] >= 'A' && twoTask[0] <= 'Z' {
 		tnsnames, err := FindTns()
-		dsn, ok := tnsnames[twoTask]
-		if err == nil && ok {
-			envUpsert(&attr, "mysql_datasource", dsn)
-			logger.GetLogger().Log(logger.Debug, "looked up mysql "+twoTask+" in tnsnames "+dsn)
-		} else {
-			logger.GetLogger().Log(logger.Alert, "could not lookup mysql "+twoTask+" in tnsnames")
+		if err == nil {
+			dsn, ok := tnsnames[twoTask]
+			if ok {
+				envUpsert(&attr, "mysql_datasource", dsn)
+				logger.GetLogger().Log(logger.Debug, "looked up datasource "+twoTask+" in tnsnames "+dsn)
+			} else {
+				logger.GetLogger().Log(logger.Alert, "mux could not lookup "+twoTask+" in tnsnames, hoping client library can lookup")
+			}
 		}
-	} else {
-		envUpsert(&attr, "mysql_datasource", twoTask)
 	}
 
 	socketPair, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM, 0)


### PR DESCRIPTION
The datasource name lookup log message was a bit confusing since it can display for all workers (oracle, mysql, postgres).  Rewording may help.