### PR TITLE
faster bind throttle decr

### DIFF
--- a/lib/bindevict.go
+++ b/lib/bindevict.go
@@ -123,6 +123,13 @@ func (be *BindEvict) ShouldBlock(sqlhash uint32, bindKV map[string]string, heavy
 		/* matched bind name and value
 		we stop searching and should return something */
 
+		// update based on usage
+		if heavyUsage {
+			entry.incrAllowEveryX()
+		} else {
+			entry.decrAllowEveryX(2)
+		}
+
 		// check if not used in a while
 		now := time.Now()
 		recent := entry.RecentAttempt.Load().(*time.Time)
@@ -138,13 +145,6 @@ func (be *BindEvict) ShouldBlock(sqlhash uint32, bindKV map[string]string, heavy
 			return true/*block*/, entry
 		}
 		entry.AllowEveryXCount = 0
-
-		// update based on usage
-		if heavyUsage {
-			entry.incrAllowEveryX()
-		} else {
-			entry.decrAllowEveryX(2)
-		}
 
 		return false, nil
 	}


### PR DESCRIPTION
The load-based decrement only happened when a query was allowed through. This makes it really slow when the block is at 0.01% (allow every 9000).

Moving the "if heavyUsage" to before the allow part makes the adjustment faster. The 3x in the incr suggests that we needed faster adjustment.