### PR TITLE
space between args, alert log msg to cal

### DIFF
--- a/utility/logger/logger.go
+++ b/utility/logger/logger.go
@@ -123,7 +123,8 @@ func (logger *logger) Log(severity int32, a ...interface{}) {
 		logger.fileLogger.Println(a...)
 		if severity == Alert {
 			evt := cal.NewCalEvent("LOGGER", "ALERT", cal.TransOK, "")
-			evt.AddDataStr("Data", fmt.Sprint(a...))
+			aJoined := fmt.Sprintln(a...)
+			evt.AddDataStr("Data", aJoined[:len(aJoined)-1])
 			evt.Completed()
 		}
 	}


### PR DESCRIPTION
The alert log messages into cal were having spaces not appear between them. This works around by using fmt.Sprintln .