### PR TITLE
upsert username/password env only when dbUsername/dbPassword is present

### DIFF
--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -352,12 +352,11 @@ func (worker *WorkerClient) StartWorker() (err error) {
 		}
 	}
 
-	_, ok := os.LookupEnv("username")
-	if !ok {
+	if dbUserName != "" {
 		envUpsert(&attr, "username", dbUserName)
 	}
-	_, ok = os.LookupEnv("password")
-	if !ok {
+
+	if dbPassword != "" {
 		envUpsert(&attr, "password", dbPassword)
 	}
 	envUpsert(&attr, "password2", dbPassword2)


### PR DESCRIPTION
Upsert the environment to use the DB credentials (dbUsername/dbPassword) obtained from secrets. If not, use the username/password from env. 