### PR TITLE
fix empty check for 2nd and 3rd password

### DIFF
--- a/lib/workerclient.go
+++ b/lib/workerclient.go
@@ -363,8 +363,15 @@ func (worker *WorkerClient) StartWorker() (err error) {
 	if dbPassword != "" {
 		envUpsert(&attr, "password", dbPassword)
 	}
-	envUpsert(&attr, "password2", dbPassword2)
-	envUpsert(&attr, "password3", dbPassword3)
+
+	if dbPassword2 != "" {
+		envUpsert(&attr, "password2", dbPassword2)
+	}
+
+	if dbPassword3 != "" {
+		envUpsert(&attr, "password3", dbPassword3)
+	}
+
 	envUpsert(&attr, "mysql_datasource", twoTask)
 	if twoTask[0] >= 'A' && twoTask[0] <= 'Z' {
 		tnsnames, err := FindTns()


### PR DESCRIPTION
The variables are default to empty string and the upsert overwrites the environment variable that may have been set during the lunching process resulting in workers always fetch empty string from the password2 and password3 env variables.