### PR TITLE
do not enable sharding without shard key name config

### DIFF
--- a/lib/cfgFromTns.go
+++ b/lib/cfgFromTns.go
@@ -78,7 +78,6 @@ func CfgFromTns(name string) {
 		numShards++
 	}
 	if numShards > 0 {
-		GetConfig().EnableSharding=true
 		GetConfig().NumOfShards=numShards
 		// shard key must be configured
 		logErr(fmt.Sprintf("numShards=%d taf:%d rw:%d",numShards,tafShards,rwShards))


### PR DESCRIPTION
When tnsnames.ora had the XYZ_SH0 and XYZ_SH1, sharding turned on without a shard key name. This made queries break.