### PR TITLE
enable optional logging of bind value hash

### DIFF
--- a/worker/cppworker/utility/StringUtil.cpp
+++ b/worker/cppworker/utility/StringUtil.cpp
@@ -65,6 +65,13 @@ std::string& StringUtil::fmt_ulong(std::string& str, const unsigned long& val) {
     return str;
 }
 
+std::string& StringUtil::fmt_ullong(std::string& str, const unsigned long long& val) {
+    std::ostringstream os;
+    os << val;
+    str = os.str();
+    return str;
+}
+
 int StringUtil::to_int(const std::string& str) {
     int result = 0;
     const char* p = str.c_str();

--- a/worker/cppworker/utility/StringUtil.h
+++ b/worker/cppworker/utility/StringUtil.h
@@ -26,6 +26,7 @@ class StringUtil {
         static bool ends_with(const std::string& str, const std::string& end);
         static std::string& fmt_int(std::string& str, const int& val);
         static std::string& fmt_ulong(std::string& str, const unsigned long& val);
+        static std::string& fmt_ullong(std::string& str, const unsigned long long& val);
         static unsigned int fmt_uint(char * s,unsigned int u);
         static int to_int(const std::string& str);
         static unsigned int to_uint(const std::string& str);

--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -3901,7 +3901,7 @@ int OCCChild::execute(int& _cmd_rc)
 		binder = bind_array->at(i).get();
 		if (config->is_switch_enabled("enable_bind_hash_logging", false)) {
 			unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(binder->value).c_str(), FNV1_64A_INIT);
-			StringUtil::fmt_ulong(bind_hash_str_val, hash_val);
+			StringUtil::fmt_ullong(bind_hash_str_val, hash_val);
 			client_session.get_session_transaction()->AddData(binder->name, bind_hash_str_val);
 			bind_hash_str_val.clear();
 		}

--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -27,7 +27,7 @@
 #include <unistd.h>
 #include <math.h>
 #include <string.h>
-
+#include <utility/fnv/fnv.h>
 #include <oci.h>
 #include <xa.h>
 
@@ -1027,6 +1027,15 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 
 			if (c)
 			{
+                               if (config->is_switch_enabled("enable_bind_hash_logging", FALSE)) {
+                                       std::string bind_hash_str_val;
+                                       for (unsigned int i = 0; i < bind_array->size(); i++) {
+                                               unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(bind_array->at(i).get()->value).c_str(), FNV1_64A_INIT);
+                                               StringUtil::fmt_ulong(bind_hash_str_val, hash_val);
+                                               c->AddData(bind_array->at(i).get()->name, bind_hash_str_val);
+                                               bind_hash_str_val.clear();
+                                       }
+                               }
 				c->SetStatus(CAL::TRANS_OK); // SQL errors are logged to CAL separately
 				delete c;
 				c = NULL;

--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -1027,6 +1027,15 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 
 			if (c)
 			{
+				if (config->is_switch_enabled("enable_bind_hash_logging", false)) {
+					std::string bind_hash_str_val;
+					for (unsigned int i = 0; i < bind_array->size(); i++) {
+						unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(bind_array->at(i).get()->value).c_str(), FNV1_64A_INIT);
+						StringUtil::fmt_ullong(bind_hash_str_val, hash_val);
+						c->AddData(bind_array->at(i).get()->name, bind_hash_str_val);
+						bind_hash_str_val.clear();
+					}
+                		}
 				c->SetStatus(CAL::TRANS_OK); // SQL errors are logged to CAL separately
 				delete c;
 				c = NULL;
@@ -3894,17 +3903,10 @@ int OCCChild::execute(int& _cmd_rc)
 		return -1;
 	}
 
-	std::string bind_hash_str_val;
 	//check if we need to send up BLOB data as part of a bind
 	for (i = 0; i < bind_array->size(); i++)
 	{
 		binder = bind_array->at(i).get();
-		if (config->is_switch_enabled("enable_bind_hash_logging", false)) {
-			unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(binder->value).c_str(), FNV1_64A_INIT);
-			StringUtil::fmt_ullong(bind_hash_str_val, hash_val);
-			client_session.get_session_transaction()->AddData(binder->name, bind_hash_str_val);
-			bind_hash_str_val.clear();
-		}
 		if(binder->lob) {
 			//write the data
 			lob_size = binder->value.length();


### PR DESCRIPTION
If enable_bind_hash_logging is enabled - it will log the bind value hash to the EXEC CAL Txn. 