### PR TITLE
changes for handling mux child processes when mux dies

### DIFF
--- a/lib/main.go
+++ b/lib/main.go
@@ -186,8 +186,8 @@ func Run() {
 }
 
 /*
- * When mux dies with any reason like death from explisit OS signal or due to any panioc errors
- * It will kills the all mux childred by using mux process ID and relase CAL resources
+ * When mux dies with any reason like death from explicit OS signal or due to any panic errors
+ * then it will kills all mux children by using mux process ID and relase CAL resources.
  */
 func handlePanicAndReleaseResource(mux_process_id int) {
 	// detect if panic occurs or not


### PR DESCRIPTION
Added Code in MUX to handle Zombie/defunct process issues in case MUX died due to any panic errors.

Verified following cases:
1. If MUX killed through SIGKILL(9) then process can't handle this signal, only parent watchdog can handle child death through SIGCHLD signal. In this case watchdog will make sure to kill all grand childs(workers) and release resource but we can't avoid zombie process issue in this case.
2. Raise panic in process and make sure it releases system resource