### PR TITLE
increase bind throttle recover rate

### DIFF
--- a/lib/config.go
+++ b/lib/config.go
@@ -417,7 +417,7 @@ func InitConfig() error {
 	default_evict_names := fmt.Sprintf("id,num,%s", SrcPrefixAppKey)
 	gAppConfig.BindEvictionNames = cdb.GetOrDefaultString("bind_eviction_names", default_evict_names)
 	gAppConfig.BindEvictionThresholdPct = cdb.GetOrDefaultInt("bind_eviction_threshold_pct", 60)
-	fmt.Sscanf(cdb.GetOrDefaultString("bind_eviction_decr_per_sec", "1.0"),
+	fmt.Sscanf(cdb.GetOrDefaultString("bind_eviction_decr_per_sec", "10.0"),
 		"%f", &gAppConfig.BindEvictionDecrPerSec)
 
 	gAppConfig.SkipEvictRegex= cdb.GetOrDefaultString("skip_eviction_host_prefix","")


### PR DESCRIPTION
The throttle rate is incremented each time by multiplying existing rate with 3. The decremental by 1 per second could be much slower than the expected throttle clearance, adjusting to 10 as global default.