### PR TITLE
Changes to sample bind hash logging

### DIFF
--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -244,7 +244,9 @@ OCCChild::OCCChild(const InitParams& _params) : Worker(_params),
 	m_last_exec_rc(OCIR_OK),
 	m_restart_window(DEFAULT_WINDOW),
 	m_sql_rewritten(false),
-	m_enable_sql_rewrite(false)
+	m_enable_sql_rewrite(false),
+	bits_to_match(0),
+	bit_mask(0)
 {
 
 	std::string cval;
@@ -299,6 +301,12 @@ OCCChild::OCCChild(const InitParams& _params) : Worker(_params),
 	if (!max_fetch_block_size)
 		max_fetch_block_size = DEFAULT_MAX_FETCH_BLOCK_SIZE;
 	max_rows = max_fetch_block_size;
+
+	if (config->get_value("bits_to_match", cval)) {
+		bits_to_match = StringUtil::to_int(cval);
+	}
+
+	bit_mask = (1<<bits_to_match) - 1;
 
 	// use non-blocking calls?
 	use_nonblock = config->is_switch_enabled("use_nonblocking", FALSE);
@@ -1028,14 +1036,19 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 			if (c)
 			{
 				if (config->is_switch_enabled("enable_bind_hash_logging", false)) {
-					std::string bind_hash_str_val;
-					for (unsigned int i = 0; i < bind_array->size(); i++) {
-						unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(bind_array->at(i).get()->value).c_str(), FNV1_64A_INIT);
-						StringUtil::fmt_ullong(bind_hash_str_val, hash_val);
-						c->AddData(bind_array->at(i).get()->name, bind_hash_str_val);
-						bind_hash_str_val.clear();
+					WRITE_LOG_ENTRY(logfile, LOG_WARNING, "enable_bind_hash_logging is enabled... bits_to_match: %d, bit_mask: %d, corr_id: %s", bits_to_match, bit_mask, m_corr_id.c_str());
+					unsigned long long int  corrid = strtoull(m_corr_id.c_str(), NULL , 16);
+					if (bit_mask == (corrid & bit_mask)) { // Allow
+						WRITE_LOG_ENTRY(logfile, LOG_WARNING, "corr_id is allowed. corr_id: %s, bit_mask: %d", m_corr_id.c_str(), bit_mask);
+						std::string bind_hash_str_val;
+						for (unsigned int i = 0; i < bind_array->size(); i++) {
+							unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(bind_array->at(i).get()->value).c_str(), FNV1_64A_INIT);
+							StringUtil::fmt_ullong(bind_hash_str_val, hash_val);
+							c->AddData(bind_array->at(i).get()->name, bind_hash_str_val);
+							bind_hash_str_val.clear();
+						}
 					}
-                		}
+                }
 				c->SetStatus(CAL::TRANS_OK); // SQL errors are logged to CAL separately
 				delete c;
 				c = NULL;

--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -245,7 +245,7 @@ OCCChild::OCCChild(const InitParams& _params) : Worker(_params),
 	m_restart_window(DEFAULT_WINDOW),
 	m_sql_rewritten(false),
 	m_enable_sql_rewrite(false),
-	bits_to_match(0),
+	bits_to_match(1),
 	bit_mask(0)
 {
 
@@ -307,7 +307,9 @@ OCCChild::OCCChild(const InitParams& _params) : Worker(_params),
 	}
 
 	bit_mask = (1<<bits_to_match) - 1;
-
+	if (config->is_switch_enabled("enable_bind_hash_logging", false)) {
+		WRITE_LOG_ENTRY(logfile, LOG_WARNING, "bind hash logging is enabled...bits_to_match: %d, bit_mask: %llu", bits_to_match, bit_mask);
+	}
 	// use non-blocking calls?
 	use_nonblock = config->is_switch_enabled("use_nonblocking", FALSE);
 
@@ -1036,10 +1038,21 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 			if (c)
 			{
 				if (config->is_switch_enabled("enable_bind_hash_logging", false)) {
-					WRITE_LOG_ENTRY(logfile, LOG_WARNING, "enable_bind_hash_logging is enabled... bits_to_match: %d, bit_mask: %d, corr_id: %s", bits_to_match, bit_mask, m_corr_id.c_str());
-					unsigned long long int  corrid = strtoull(m_corr_id.c_str(), NULL , 16);
+					unsigned long long int corrid = strtoull(m_corr_id.c_str(), NULL , 16);	
+					if (errno == ERANGE) {
+						std::ostringstream msg;
+						msg << "m_err=error on strtoull(), errno=" << errno;
+						WRITE_LOG_ENTRY(logfile, LOG_WARNING, "%s", msg.str().c_str());
+						errno = 0;
+						CalEvent e_name("BIND_HASH_LOGGING", m_query_hash, CAL::TRANS_ERROR);
+						e_name.AddData(msg.str());
+						e_name.AddData("corr_id_", m_corr_id);
+						e_name.Completed();
+					}
 					if (bit_mask == (corrid & bit_mask)) { // Allow
-						WRITE_LOG_ENTRY(logfile, LOG_WARNING, "corr_id is allowed. corr_id: %s, bit_mask: %d", m_corr_id.c_str(), bit_mask);
+						CalEvent e_name("BIND_HASH_LOGGING", m_query_hash, CAL::TRANS_OK);
+						e_name.AddData("corr_id_", m_corr_id);
+						e_name.Completed();
 						std::string bind_hash_str_val;
 						for (unsigned int i = 0; i < bind_array->size(); i++) {
 							unsigned long long hash_val = fnv_64a_str(StringUtil::hex_escape(bind_array->at(i).get()->value).c_str(), FNV1_64A_INIT);
@@ -1048,7 +1061,7 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 							bind_hash_str_val.clear();
 						}
 					}
-                }
+                		}
 				c->SetStatus(CAL::TRANS_OK); // SQL errors are logged to CAL separately
 				delete c;
 				c = NULL;

--- a/worker/cppworker/worker/OCCChild.h
+++ b/worker/cppworker/worker/OCCChild.h
@@ -275,8 +275,8 @@ private:
 	bool m_sql_rewritten;
 	bool m_enable_sql_rewrite;
 	std::string m_orig_query_hash;
-	int bits_to_match; // Sampled Bind Hash logging
-	int bit_mask; // Compute based on bits_to_match
+	int bits_to_match; // Sampled Bind Hash logging. Sampling ratio (1:pow(2,bits_to_match)). Default 1 (Sampling ratio 1:2)
+	unsigned long long int bit_mask; // Compute based on bits_to_match
 
 public:
 	// need to pass in a server socket which is already bound to the correct port

--- a/worker/cppworker/worker/OCCChild.h
+++ b/worker/cppworker/worker/OCCChild.h
@@ -275,6 +275,8 @@ private:
 	bool m_sql_rewritten;
 	bool m_enable_sql_rewrite;
 	std::string m_orig_query_hash;
+	int bits_to_match; // Sampled Bind Hash logging
+	int bit_mask; // Compute based on bits_to_match
 
 public:
 	// need to pass in a server socket which is already bound to the correct port


### PR DESCRIPTION
Introduces sampling when bind hash logging is enabled. It also adds a new event 'BIND_HASH_LOGGING' to get the number of samples logged. 

t14:50:32.01	API	CLIENT_SESSION
t14:50:32.01	EXEC	1345906010
E14:50:32.01	BIND_HASH_LOGGING	1345906010	0	corr_id_=c08f4c663da6f
T14:50:32.01	EXEC	1345906010	0	2.3	HOST=FOO&id=577317304958921412&name=18026779120476653122
E14:50:32.11	COMMIT	Local	0
T14:50:32.12	API	CLIENT_SESSION	0	114	corr_id_=c08f4c663da6f&log_id_=185c713a6ca&worker_pid=574445&sid=13