### PR TITLE
mysql 8.0 to run in mac m1

### DIFF
--- a/tests/unittest/testutil/setup.go
+++ b/tests/unittest/testutil/setup.go
@@ -191,7 +191,7 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 		if os.Getenv("GITHUB_JOB") == "" {
 			CleanDB(dockerName)
 
-			cmd := exec.Command("docker", "run", "-p3306:3306", "--name", dockerName, "-e", "MYSQL_ROOT_PASSWORD=1-testDb", "-e", "MYSQL_DATABASE="+dbName, "-d", "mysql:5.7")
+			cmd := exec.Command("docker", "run", "-p3306:3306", "--name", dockerName, "-e", "MYSQL_ROOT_PASSWORD=1-testDb", "-e", "MYSQL_DATABASE="+dbName, "-d", "mysql:8.0")
 			cmd.Run()
 		}
 


### PR DESCRIPTION
Trying 

$GOROOT/bin/go mod download github.com/godror/godror
$GOROOT/bin/go mod download github.com/lib/pq
$GOROOT/bin/go install github.com/paypal/hera/worker/mysqlworker
cp $GOPATH/bin/mysqlworker .
$GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/coordinator_basic
./coordinator_basic.test

Silently fails since "docker run .. mysql:5.7" fails with

5.7: Pulling from library/mysql
no matching manifest for linux/arm64/v8 in the manifest list entries                        
 
Using 8.0 fixes it