### PR TITLE
fixing concurrent map read and map write

### DIFF
--- a/lib/adaptivequemgr.go
+++ b/lib/adaptivequemgr.go
@@ -138,9 +138,11 @@ func bindEvictNameOk(bindName string) (bool) {
 bind name and values */
 func (mgr *adaptiveQueueManager) doBindEviction() (int) {
 	throttleCount := 0
+	GetBindEvict().lock.Lock()
 	for _,keyValues := range GetBindEvict().BindThrottle {
 		throttleCount += len(keyValues)
 	}
+	GetBindEvict().lock.Unlock()
 	if throttleCount > GetConfig().BindEvictionMaxThrottle {
 		if logger.GetLogger().V(logger.Info) {
 			logger.GetLogger().Log(logger.Info, "already too many bind throttles, skipping bind eviction and throttle")
@@ -157,7 +159,9 @@ func (mgr *adaptiveQueueManager) doBindEviction() (int) {
 		}
 		usqlhash := uint32(worker.sqlHash)
 		sqlhash := atomic.LoadUint32(&(usqlhash))
+		GetBindEvict().lock.Lock()
 		_, ok := GetBindEvict().BindThrottle[sqlhash]
+		GetBindEvict().lock.Unlock()
 		if ok {
 			continue // don't repeatedly bind evict something already evicted
 		}
@@ -257,11 +261,13 @@ func (mgr *adaptiveQueueManager) doBindEviction() (int) {
 		}
 
 		// setup allow-every-x
+		GetBindEvict().lock.Lock()
 		sqlBind, ok := GetBindEvict().BindThrottle[sqlhash]
 		if !ok {
 			sqlBind = make(map[string]*BindThrottle)
 			GetBindEvict().BindThrottle[sqlhash] = sqlBind
 		}
+		GetBindEvict().lock.Unlock()
 		concatKey := fmt.Sprintf("%s|%s", bindName, bindValue)
 		throttle, ok := sqlBind[concatKey]
 		if ok {

--- a/lib/coordinator.go
+++ b/lib/coordinator.go
@@ -643,7 +643,9 @@ func (crd *Coordinator) dispatchRequest(request *netstring.Netstring) error {
 	xShardRead := false
 
 	// check bind throttle
+	GetBindEvict().lock.Lock()
 	_, ok := GetBindEvict().BindThrottle[uint32(crd.sqlhash)]
+	GetBindEvict().lock.Unlock()
 	if ok {
 		wType := wtypeRW
 		cfg := GetNumWorkers(crd.shard.shardID)


### PR DESCRIPTION
fatal error: concurrent map read and map write

goroutine 3213923077 [running]:
runtime.throw({0x81bc1c?, 0xc0011180f0?})
        /usr/local/go1.18.2/go/src/runtime/panic.go:992 +0x71 fp=0xc0009d3798 sp=0xc0009d3768 pc=0x437191
runtime.mapaccess2_fast32(0xc0009d3830?, 0x0?, 0x8480f088)
        /usr/local/go1.18.2/go/src/runtime/map_fast32.go:62 +0x176 fp=0xc0009d37b8 sp=0xc0009d3798 pc=0x412356
github.com/paypal/hera/lib.(*Coordinator).dispatchRequest(0xc003d57600, 0xc002920e00)
        /go1.18.2/src/github.com/paypal/hera/lib/coordinator.go:646 +0x196 fp=0xc0009d3ae8 sp=0xc0009d37b8 pc=0x733ff6
github.com/paypal/hera/lib.(*Coordinator).dispatch(0xc003d57600, 0xc0009d3bc0?)
        /go1.18.2/src/github.com/paypal/hera/lib/coordinator.go:324 +0x6b fp=0xc0009d3b20 sp=0xc0009d3ae8 pc=0x7321cb
github.com/paypal/hera/lib.(*Coordinator).Run(0xc003d57600)
        /go1.18.2/src/github.com/paypal/hera/lib/coordinator.go:165 +0xb8a fp=0xc0009d3fc8 sp=0xc0009d3b20 pc=0x7304ea
github.com/paypal/hera/lib.HandleConnection.func2()
        /go1.18.2/src/github.com/paypal/hera/lib/connectionhandler.go:83 +0x26 fp=0xc0009d3fe0 sp=0xc0009d3fc8 pc=0x72e826
runtime.goexit()
        /usr/local/go1.18.2/go/src/runtime/asm_amd64.s:1571 +0x1 fp=0xc0009d3fe8 sp=0xc0009d3fe0 pc=0x469b61
created by github.com/paypal/hera/lib.HandleConnection
        /go1.18.2/src/github.com/paypal/hera/lib/connectionhandler.go:83 +0x16a