### PR TITLE
compute scuttle id for string shard keys

### DIFF
--- a/worker/cppworker/utility/HashUtil.cpp
+++ b/worker/cppworker/utility/HashUtil.cpp
@@ -1,5 +1,6 @@
 // On 2020-07, https://github.com/aappleby/smhasher notes that MurmurHash is public domain
 #include "HashUtil.h"
+#include <string>
 
 // just in this file
 static uint32_t MurmurHash3(const char * key, int len);
@@ -11,6 +12,11 @@ uint32_t HashUtil::MurmurHash3Sharding(const long long key)
 uint32_t HashUtil::MurmurHash3(const long long key)
 {
 	return ::MurmurHash3((const char*)&key, sizeof(long long));
+}
+uint32_t HashUtil::MurmurHash3(std::string key)
+{
+	const char *shardkey_bytes = const_cast<char*>(key.c_str());
+	return ::MurmurHash3(shardkey_bytes, key.size());
 }
 
 //https://code.google.com/p/smhasher/wiki/MurmurHash3

--- a/worker/cppworker/utility/HashUtil.h
+++ b/worker/cppworker/utility/HashUtil.h
@@ -18,6 +18,7 @@
 #define HASH_UTIL_H
 
 #include <stdint.h>
+#include <string>
 
 class HashUtil {
 public:
@@ -26,6 +27,9 @@ public:
 
 	/** Deprecated, only for sharding. */
 	static uint32_t MurmurHash3(const long long key);
+
+	/** Deprecated, only for sharding. */
+	static uint32_t MurmurHash3(std::string key);
 };
 
 #endif // HASH_UTIL_H

--- a/worker/cppworker/worker/OCCChild.h
+++ b/worker/cppworker/worker/OCCChild.h
@@ -274,6 +274,7 @@ private:
 	SQLRewriter m_rewriter;
 	bool m_sql_rewritten;
 	bool m_enable_sql_rewrite;
+	bool m_shard_key_value_type_string;
 	std::string m_orig_query_hash;
 	int bits_to_match; // Sampled Bind Hash logging. Sampling ratio (1:pow(2,bits_to_match)). Default 1 (Sampling ratio 1:2)
 	unsigned long long int bit_mask; // Compute based on bits_to_match
@@ -515,7 +516,8 @@ private:
 	int trans_forget(void);
 	// check with oracle if we're in transaction
 	virtual bool is_in_transaction();
-    virtual uint compute_scuttle_id(unsigned long long _shardkey_val);
+	virtual uint compute_scuttle_id(unsigned long long _shardkey_val);
+	virtual uint compute_scuttle_id(std::string _shardkey_str_val);
 
 	// handle OCI_SUCCESS_WITH_INFO
 	void check_OCI_SUCCESS_WITH_INFO(int& _rc, const char* _message, LogLevelEnum _log_level);


### PR DESCRIPTION
Fix for Issue #320. Also handles string shard keys for OCC_SHARD_KEY.