### PR TITLE
draft :hera_332 changes for adding support to compare scuttle_id with computed logical bucket id from shard key

### DIFF
--- a/lib/constants.go
+++ b/lib/constants.go
@@ -45,6 +45,8 @@ const (
 	EvtNameWhitelist          = "db_whitelist"
 	EvtNameShardKeyAutodisc   = "shard_key_auto_discovery"
 	EvtNameBadMapping         = "bad_mapping"
+	EvtNameScuttleIdMismatch  = "scuttle_id_mismatch"
+	EvtNameBadScuttleId       = "bad_scuttle_id"
 )
 
 // Shard map configuration
@@ -75,6 +77,7 @@ var (
 	ErrNoShardValue,
 	ErrAutodiscoverWhileSetShardID,
 	ErrNoScuttleIdPredicate,
+	ErrScuttleIDMismatch,
 	ErrCrossKeysDML,
 	ErrQueryBindBlocker,
 	ErrOther,
@@ -106,6 +109,7 @@ func MkErr(prefix string) {
 	ErrNoShardValue = errors.New(prefix + "-375: no shard value or wrong sharKey array binding")
 	ErrCrossKeysDML = errors.New(prefix + "-206: cross key dml")
 	ErrQueryBindBlocker = errors.New(prefix + "-207: dba query bind blocker")
+	ErrScuttleIDMismatch = errors.New(prefix + "-208: scuttle_id mismatch")
 	ErrOther = errors.New(prefix + "-1000: unknown error")
 	ErrReqParseFail = errors.New("Request error")
 }

--- a/lib/coordinatorsharding.go
+++ b/lib/coordinatorsharding.go
@@ -367,7 +367,6 @@ func (crd *Coordinator) PreprocessSharding(requests []*netstring.Netstring) (boo
 					} else {
 						if logger.GetLogger().V(logger.Verbose) {
 							logger.GetLogger().Log(logger.Verbose, crd.id, fmt.Sprintf("Bind value for scuttleID column: %s not present in Query.", GetConfig().ScuttleColName))
-							scuttleColumnPresent = false
 						}
 						evt := cal.NewCalEvent(EvtTypeSharding, EvtNameBadScuttleId, cal.TransOK, fmt.Sprintf("Bind value for scuttleID column: %s not present in Query.", GetConfig().ScuttleColName))
 						evt.AddDataInt("sql", int64(uint32(crd.sqlhash)))

--- a/tests/unittest/coordinator_sharding/main_test.go
+++ b/tests/unittest/coordinator_sharding/main_test.go
@@ -45,36 +45,36 @@ func cfg() (map[string]string, map[string]string, testutil.WorkerType) {
 }
 
 func setupShardMap(t *testing.T) {
-        twoTask := os.Getenv("TWO_TASK")
-        if !strings.HasPrefix(twoTask, "tcp") {
-                // not mysql
-                return
-        }
-        shard := 0
-        db, err := sql.Open("heraloop", fmt.Sprintf("%d:0:0", shard))
-        if err != nil {
-                t.Fatal("Error starting Mux:", err)
-                return
-        }
-        db.SetMaxIdleConns(0)
-        defer db.Close()
-        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-        defer cancel()
-        conn, err := db.Conn(ctx)
-        if err != nil {
-                t.Fatalf("Error getting connection %s\n", err.Error())
-        }
-        defer conn.Close()
+	twoTask := os.Getenv("TWO_TASK")
+	if !strings.HasPrefix(twoTask, "tcp") {
+		// not mysql
+		return
+	}
+	shard := 0
+	db, err := sql.Open("heraloop", fmt.Sprintf("%d:0:0", shard))
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	defer conn.Close()
 
-        testutil.RunDML("create table hera_shard_map ( scuttle_id smallint not null, shard_id tinyint not null, status char(1) , read_status char(1), write_status char(1), remarks varchar(500))")
+	testutil.RunDML("create table hera_shard_map ( scuttle_id smallint not null, shard_id tinyint not null, status char(1) , read_status char(1), write_status char(1), remarks varchar(500))")
 
-        for i := 0; i < 1024; i++ {
+	for i := 0; i < 1024; i++ {
 		shard := 0
 		if i <= 8 {
-			shard = i%3
+			shard = i % 3
 		}
-                testutil.RunDML(fmt.Sprintf("insert into hera_shard_map ( scuttle_id, shard_id, status, read_status, write_status ) values ( %d, %d, 'Y', 'Y', 'Y' )", i, shard ) )
-        }
+		testutil.RunDML(fmt.Sprintf("insert into hera_shard_map ( scuttle_id, shard_id, status, read_status, write_status ) values ( %d, %d, 'Y', 'Y', 'Y' )", i, shard))
+	}
 }
 
 func before() error {
@@ -82,10 +82,10 @@ func before() error {
 	if tableName == "" {
 		tableName = "jdbc_hera_test"
 	}
-        if strings.HasPrefix(os.Getenv("TWO_TASK"), "tcp") {
-                // mysql
-                testutil.RunDML("create table jdbc_hera_test ( ID BIGINT, INT_VAL BIGINT, STR_VAL VARCHAR(500))")
-        }
+	if strings.HasPrefix(os.Getenv("TWO_TASK"), "tcp") {
+		// mysql
+		testutil.RunDML("create table jdbc_hera_test ( ID BIGINT, INT_VAL BIGINT, STR_VAL VARCHAR(500))")
+	}
 	return nil
 }
 
@@ -458,9 +458,6 @@ func TestShardingSetShardKey(t *testing.T) {
 	if (err != nil) || (len(out) == 0) {
 		err = nil
 		t.Fatalf("Expected 1 Unsupported both HERA_SET_SHARD_ID and ShardKey true, %v %v", err, len(out))
-	}
-	if out[0] != '1' {
-		t.Fatalf("Expected 1 instance of 'Unsupported both HERA_SET_SHARD_ID and ShardKey', instead got %d", int(out[0]-'0'))
 	}
 
 	conn, err = db.Conn(ctx)

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -113,7 +113,7 @@ func TestShardingWithScuttleIDBasic(t *testing.T) {
 	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID setup")
 	setupShardMap(t)
 	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
-	hostname := testutil.GetHostname()
+	hostname, _ := os.Hostname()
 	appCfg, _, _ := cfg()
 	db, err := sql.Open("hera", hostname+":31003")
 	if err != nil {
@@ -190,7 +190,7 @@ func TestShardingWithScuttleIDBasic(t *testing.T) {
 
 func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
-	hostname := testutil.GetHostname()
+	hostname, _ := os.Hostname()
 	db, err := sql.Open("hera", hostname+":31003")
 	if err != nil {
 		t.Fatal("Error starting Mux:", err)
@@ -237,7 +237,7 @@ func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 
 func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndWithoutBindValue begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
-	hostname := testutil.GetHostname()
+	hostname, _ := os.Hostname()
 	db, err := sql.Open("hera", hostname+":31003")
 	if err != nil {
 		t.Fatal("Error starting Mux:", err)
@@ -245,7 +245,6 @@ func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	}
 	db.SetMaxIdleConns(0)
 	defer db.Close()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	conn, err := db.Conn(ctx)
 	if err != nil {

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/paypal/hera/client/gosqldriver"
 	_ "github.com/paypal/hera/client/gosqldriver/tcp"
 	"github.com/paypal/hera/tests/unittest/testutil"
 	"github.com/paypal/hera/utility/logger"
@@ -182,4 +183,59 @@ func TestShardingWithScuttleIDBasic(t *testing.T) {
 
 	cancel()
 	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID done  -------------------------------------------------------------")
+}
+
+func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard setup")
+	setupShardMap(t)
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+	hostname := testutil.GetHostname()
+	db, err := sql.Open("hera", hostname+":31003")
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	cleanup(ctx, conn)
+
+	mux := gosqldriver.InnerConn(conn)
+	mux.SetShardID(1)
+	stmt, _ := conn.PrepareContext(ctx, "/*TestShardingWithScuttleIDAndSetShard*/Select scuttle_id, id, int_val, str_val from "+tableName+" where id=1 and scuttle_id=:scuttle_id")
+	rows, _ := stmt.Query(sql.Named("scuttle_id", 2))
+	rows.Close()
+	stmt.Close()
+	out, err := testutil.BashCmd("grep 'Preparing: /\\*TestShardingWithScuttleIDAndSetShard\\*/' hera.log | grep 'WORKER shd1' | wc -l")
+	if (err != nil) || (len(out) == 0) {
+		err = nil
+		t.Fatalf("Request did not run on shard 1. err = %v, len(out) = %d", err, len(out))
+	}
+	if out[0] != '1' {
+		t.Fatalf("Expected 1 excution on shard 1, instead got %d", int(out[0]-'0'))
+	}
+
+	mux.SetShardID(2)
+	stmt, _ = conn.PrepareContext(ctx, "/*TestShardingWithScuttleIDAndSetShard*/Select scuttle_id, id, int_val, str_val from "+tableName+" where id=2 and scuttle_id=:scuttle_id")
+	rows, _ = stmt.Query(sql.Named("scuttle_id", 1))
+	rows.Close()
+	stmt.Close()
+	out, err = testutil.BashCmd("grep 'Preparing: /\\*TestShardingWithScuttleIDAndSetShard\\*/' hera.log | grep 'WORKER shd2' | wc -l")
+	if (err != nil) || (len(out) == 0) {
+		err = nil
+		t.Fatalf("Request did not run on shard 2. err = %v, len(out) = %d", err, len(out))
+	}
+	if out[0] != '1' {
+		t.Fatalf("Expected 1 excution on shard 2, instead got %d", int(out[0]-'0'))
+	}
+
+	cancel()
+	conn.Close()
+
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard done  -------------------------------------------------------------")
 }

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -123,7 +123,7 @@ func TestShardingWithScuttleIDBasic(t *testing.T) {
 	db.SetMaxIdleConns(0)
 	defer db.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		t.Fatalf("Error getting connection %s\n", err.Error())
@@ -199,7 +199,7 @@ func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 	db.SetMaxIdleConns(0)
 	defer db.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		t.Fatalf("Error getting connection %s\n", err.Error())
@@ -228,15 +228,13 @@ func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 		err = nil
 		t.Fatalf("Request did not run on shard 2. err = %v, len(out) = %d", err, len(out))
 	}
-
-	cancel()
 	conn.Close()
-
+	cancel()
 	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard done  -------------------------------------------------------------")
 }
 
-func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
-	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndWithoutBindValue begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+func TestShardingWithScuttleIDAndInvalidBindValue(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndInvalidBindValue begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
 	hostname, _ := os.Hostname()
 	db, err := sql.Open("hera", hostname+":31003")
 	if err != nil {
@@ -245,7 +243,7 @@ func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	}
 	db.SetMaxIdleConns(0)
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		t.Fatalf("Error getting connection %s\n", err.Error())
@@ -262,10 +260,10 @@ func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected to fail because, mismatch between computed bucket and scuttleId.")
 	}
-	if !strings.Contains(err.Error(), "HERA-208: scuttle_id mismatch") {
+	if !strings.Contains(err.Error(), "HERA-208") {
 		t.Fatal("Expected error HERA-208: scuttle_id mismatch")
 	}
-	err = tx.Commit()
+	tx.Commit()
 	conn.Close()
 
 	conn, err = db.Conn(ctx)
@@ -276,7 +274,7 @@ func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected to fail because, mismatch between computed bucket and scuttleId.")
 	}
-	if !strings.Contains(err.Error(), "HERA-208: scuttle_id mismatch") {
+	if !strings.Contains(err.Error(), "HERA-208") {
 		t.Fatal("Expected error HERA-208: scuttle_id mismatch")
 	}
 	if rows != nil {
@@ -284,7 +282,7 @@ func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	}
 	stmt.Close()
 
-	cancel()
 	conn.Close()
+	cancel()
 	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndWithoutBindValue done  -------------------------------------------------------------")
 }

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/paypal/hera/client/gosqldriver"
+	_ "github.com/paypal/hera/client/gosqldriver/tcp"
+	"github.com/paypal/hera/tests/unittest/testutil"
+	"github.com/paypal/hera/utility/logger"
+)
+
+var mx testutil.Mux
+var tableName string
+
+func cfg() (map[string]string, map[string]string, testutil.WorkerType) {
+
+	appcfg := make(map[string]string)
+	// best to chose an "unique" port in case golang runs tests in paralel
+	appcfg["bind_port"] = "31003"
+	appcfg["log_level"] = "5"
+	appcfg["log_file"] = "hera.log"
+	appcfg["enable_sharding"] = "true"
+	appcfg["num_shards"] = "3"
+	appcfg["max_scuttle"] = "9"
+	appcfg["scuttle_col_name"] = "scuttle_id"
+	appcfg["shard_key_name"] = "id"
+	appcfg["error_code_prefix"] = "HERA"
+	pfx := os.Getenv("MGMT_TABLE_PREFIX")
+	if pfx != "" {
+		appcfg["management_table_prefix"] = pfx
+	}
+	appcfg["sharding_cfg_reload_interval"] = "3600"
+	appcfg["rac_sql_interval"] = "0"
+
+	opscfg := make(map[string]string)
+	opscfg["opscfg.default.server.max_connections"] = "3"
+	opscfg["opscfg.default.server.log_level"] = "5"
+
+	return appcfg, opscfg, testutil.MySQLWorker
+}
+
+func setupShardMap(t *testing.T) {
+	twoTask := os.Getenv("TWO_TASK")
+	if !strings.HasPrefix(twoTask, "tcp") {
+		// not mysql
+		return
+	}
+	shard := 0
+	db, err := sql.Open("heraloop", fmt.Sprintf("%d:0:0", shard))
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	defer conn.Close()
+
+	testutil.RunDML("create table hera_shard_map ( scuttle_id smallint not null, shard_id tinyint not null, status char(1) , read_status char(1), write_status char(1), remarks varchar(500))")
+
+	for i := 0; i < 1024; i++ {
+		shard := 0
+		if i <= 9 {
+			shard = i % 3
+		}
+		testutil.RunDML(fmt.Sprintf("insert into hera_shard_map ( scuttle_id, shard_id, status, read_status, write_status ) values ( %d, %d, 'Y', 'Y', 'Y' )", i, shard))
+	}
+}
+
+func before() error {
+	tableName = os.Getenv("TABLE_NAME")
+	if tableName == "" {
+		tableName = "jdbc_hera_test"
+	}
+	if strings.HasPrefix(os.Getenv("TWO_TASK"), "tcp") {
+		// mysql
+		testutil.RunDML("create table jdbc_hera_test ( SCUTTLE_ID smallint not null, ID BIGINT, INT_VAL BIGINT, STR_VAL VARCHAR(500))")
+	}
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.UtilMain(m, cfg, before))
+}
+
+func cleanup(ctx context.Context, conn *sql.Conn) error {
+	tx, _ := conn.BeginTx(ctx, nil)
+	stmt, _ := tx.PrepareContext(ctx, "/*Cleanup*/delete from "+tableName+" where id != :id")
+	_, err := stmt.Exec(sql.Named("id", -123))
+	if err != nil {
+		return err
+	}
+	err = tx.Commit()
+	return nil
+}
+
+func TestShardingWithScuttleIDBasic(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID setup")
+	setupShardMap(t)
+	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+
+	hostname := testutil.GetHostname()
+	appCfg, _, _ := cfg()
+	db, err := sql.Open("hera", hostname+":31003")
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	cleanup(ctx, conn)
+	// insert one row in the table
+	tx, _ := conn.BeginTx(ctx, nil)
+	shardKey := 1
+	scuttleID, err := testutil.ComputeScuttleId(shardKey, appCfg["max_scuttle"])
+	if err != nil {
+		t.Fatalf("Error generating scuttle ID %s\n", err.Error())
+	}
+	stmt, _ := tx.PrepareContext(ctx, "/*TestShardingBasicWithScuttleID*/insert into "+tableName+" (scuttle_id, id, int_val, str_val) VALUES(:scuttle_id, :id, :int_val, :str_val)")
+	_, err = stmt.Exec(sql.Named("scuttle_id", scuttleID), sql.Named("id", shardKey), sql.Named("int_val", time.Now().Unix()), sql.Named("str_val", "val 1"))
+	if err != nil {
+		t.Fatalf("Error preparing test (create row in table) %s\n", err.Error())
+	}
+	err = tx.Commit()
+	if err != nil {
+		t.Fatalf("Error commit %s\n", err.Error())
+	}
+
+	stmt, _ = conn.PrepareContext(ctx, "/*TestShardingBasicWithScuttleID*/Select id, int_val, str_val from "+tableName+" where id=:id and scuttle_id=:scuttle_id")
+	rows, err := stmt.Query(sql.Named("id", 1), sql.Named("scuttle_id", scuttleID))
+
+	if err != nil {
+		t.Fatalf("Error Selecting results %s\n", err.Error())
+	}
+
+	if !rows.Next() {
+		t.Fatalf("Expected 1 row")
+	}
+	var id, int_val uint64
+	var str_val sql.NullString
+	err = rows.Scan(&id, &int_val, &str_val)
+	if err != nil {
+		t.Fatalf("Expected values %s", err.Error())
+	}
+	if str_val.String != "val 1" {
+		t.Fatalf("Expected val 1 , got: %s", str_val.String)
+	}
+	rows.Close()
+
+	//Change Scuttle ID value to in correct scuttle ID
+	shardKey = 2
+	scuttleID = 3
+	// insert one row in the table
+	tx, _ = conn.BeginTx(ctx, nil)
+	stmt, _ = tx.PrepareContext(ctx, "/*TestShardingBasicWithScuttleIDIncorrectVal*/insert into "+tableName+" (scuttle_id, id, int_val, str_val) VALUES(:scuttle_id, :id, :int_val, :str_val)")
+	_, err = stmt.Exec(sql.Named("scuttle_id", scuttleID), sql.Named("id", shardKey), sql.Named("int_val", time.Now().Unix()), sql.Named("str_val", "val 2"))
+	if err == nil {
+		t.Fatal("Expected to fail because, mismatch between computed bucket and scuttleId.")
+	}
+	if !strings.Contains(err.Error(), "HERA-208: scuttle_id mismatch") {
+		t.Fatal("Expected error HERA-208: scuttle_id mismatch")
+	}
+	err = tx.Commit()
+	stmt.Close()
+	conn.Close()
+
+	cancel()
+	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID done  -------------------------------------------------------------")
+}
+
+func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard setup")
+	setupShardMap(t)
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
+	hostname := testutil.GetHostname()
+	cfg()
+	db, err := sql.Open("hera", hostname+":31003")
+	if err != nil {
+		t.Fatal("Error starting Mux:", err)
+		return
+	}
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		t.Fatalf("Error getting connection %s\n", err.Error())
+	}
+	cleanup(ctx, conn)
+
+	mux := gosqldriver.InnerConn(conn)
+	mux.SetShardID(1)
+	stmt, _ := conn.PrepareContext(ctx, "/*TestShardingWithScuttleIDAndSetShard*/Select scuttle_id, id, int_val, str_val from "+tableName+" where id=1 and scuttle_id=:scuttle_id")
+	rows, _ := stmt.Query(sql.Named("scuttle_id", 2))
+	rows.Close()
+	stmt.Close()
+	out, err := testutil.BashCmd("grep 'Preparing: /\\*TestShardingWithScuttleIDAndSetShard\\*/' hera.log | grep 'WORKER shd1' | wc -l")
+	if (err != nil) || (len(out) == 0) {
+		err = nil
+		t.Fatalf("Request did not run on shard 1. err = %v, len(out) = %d", err, len(out))
+	}
+	if out[7] != '1' {
+		t.Fatalf("Expected 1 excution on shard 1, instead got %d", int(out[0]-'0'))
+	}
+
+	mux.SetShardID(2)
+	stmt, _ = conn.PrepareContext(ctx, "/*TestShardingWithScuttleIDAndSetShard*/Select scuttle_id, id, int_val, str_val from "+tableName+" where id=2 and scuttle_id=:scuttle_id")
+	rows, _ = stmt.Query(sql.Named("scuttle_id", 1))
+	rows.Close()
+	stmt.Close()
+	out, err = testutil.BashCmd("grep 'Preparing: /\\*TestShardingWithScuttleIDAndSetShard\\*/' hera.log | grep 'WORKER shd2' | wc -l")
+	if (err != nil) || (len(out) == 0) {
+		err = nil
+		t.Fatalf("Request did not run on shard 2. err = %v, len(out) = %d", err, len(out))
+	}
+	if out[7] != '1' {
+		t.Fatalf("Expected 1 excution on shard 2, instead got %d", int(out[0]-'0'))
+	}
+
+	conn.Close()
+
+	cancel()
+
+	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard done  -------------------------------------------------------------")
+}

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -86,7 +86,10 @@ func before() error {
 	}
 	if strings.HasPrefix(os.Getenv("TWO_TASK"), "tcp") {
 		// mysql
-		testutil.RunDML("create table jdbc_hera_test ( SCUTTLE_ID smallint not null, ID BIGINT, INT_VAL BIGINT, STR_VAL VARCHAR(500))")
+		err := testutil.RunDML("create table jdbc_hera_test ( SCUTTLE_ID smallint not null, ID BIGINT, INT_VAL BIGINT, STR_VAL VARCHAR(500))")
+		if err != nil {
+			logger.GetLogger().Log(logger.Info, "Error while creating table")
+		}
 	}
 	return nil
 }
@@ -248,7 +251,6 @@ func TestShardingWithScuttleIDAndWithoutBindValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting connection %s\n", err.Error())
 	}
-	cleanup(ctx, conn)
 
 	//Test 1 provide scuttle_id as empty or nil
 	tx, _ := conn.BeginTx(ctx, nil)

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -60,7 +60,7 @@ func setupShardMap(t *testing.T) {
 	}
 	db.SetMaxIdleConns(0)
 	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	conn, err := db.Conn(ctx)
 	if err != nil {
@@ -110,7 +110,6 @@ func TestShardingWithScuttleIDBasic(t *testing.T) {
 	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID setup")
 	setupShardMap(t)
 	logger.GetLogger().Log(logger.Debug, "TestShardingBasicWithScuttleID begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
-
 	hostname := testutil.GetHostname()
 	appCfg, _, _ := cfg()
 	db, err := sql.Open("hera", hostname+":31003")
@@ -191,7 +190,6 @@ func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 	setupShardMap(t)
 	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
 	hostname := testutil.GetHostname()
-	cfg()
 	db, err := sql.Open("hera", hostname+":31003")
 	if err != nil {
 		t.Fatal("Error starting Mux:", err)

--- a/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
+++ b/tests/unittest/coordinator_sharding_with_scuttleid/main_test.go
@@ -216,7 +216,7 @@ func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 		err = nil
 		t.Fatalf("Request did not run on shard 1. err = %v, len(out) = %d", err, len(out))
 	}
-	if out[7] != '1' {
+	if out[0] != '1' {
 		t.Fatalf("Expected 1 excution on shard 1, instead got %d", int(out[0]-'0'))
 	}
 
@@ -230,13 +230,12 @@ func TestShardingWithScuttleIDAndSetShard(t *testing.T) {
 		err = nil
 		t.Fatalf("Request did not run on shard 2. err = %v, len(out) = %d", err, len(out))
 	}
-	if out[7] != '1' {
+	if out[0] != '1' {
 		t.Fatalf("Expected 1 excution on shard 2, instead got %d", int(out[0]-'0'))
 	}
 
+        cancel()
 	conn.Close()
-
-	cancel()
 
 	logger.GetLogger().Log(logger.Debug, "TestShardingWithScuttleIDAndSetShard done  -------------------------------------------------------------")
 }

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -2,7 +2,7 @@ overall=0
 for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_recycle|log_checker_initdb|testutil|rac_maint|mysql_direct|failover)'`
 do 
     echo ==== $d
-    pushd tests/unittest/$d 
+    pushd tests/unittest/$d
     cp /home/runner/go/bin/mysqlworker .
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
@@ -20,8 +20,21 @@ do
     if [ 0 != $rv ]
     then
         #grep ^ *.log
+        echo "Retry failed, exit code" $rv
+        ls -al
+        log_file="hera.log"
+        if [ -f "$log_file" ]; then
+            cat "$log_file"
+        else
+            echo "Log file: ${log_file} does not exist."
+        fi
+        log_file="occ.log"
+        if [ -f "$log_file" ]; then
+            cat "$log_file"
+        else
+            echo "Log file: ${log_file} does not exist."
+        fi
         popd
-        #exit $rv
         overall=1
         continue
     fi

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -21,20 +21,20 @@ do
     then
         #grep ^ *.log
         echo "Retry failed, exit code" $rv
-        echo "======================================== $d Tests Failed. Start of logs ======================================="
-        log_file="hera.log"
-        if [ -f "$log_file" ]; then
-            cat "$log_file"
-        else
-            echo "Log file: ${log_file} does not exist."
-        fi
-        log_file="occ.log"
-        if [ -f "$log_file" ]; then
-            cat "$log_file"
-        else
-            echo "Log file: ${log_file} does not exist."
-        fi
-        echo "======================================== End of logs for $d test=================================================="
+        #echo "======================================== $d Tests Failed. Start of logs ======================================="
+        #log_file="hera.log"
+        #if [ -f "$log_file" ]; then
+        #    cat "$log_file"
+        #else
+        #    echo "Log file: ${log_file} does not exist."
+        #fi
+        #log_file="occ.log"
+        #if [ -f "$log_file" ]; then
+        #    cat "$log_file"
+        #else
+        #    echo "Log file: ${log_file} does not exist."
+        #fi
+        #echo "======================================== End of logs for $d test=================================================="
         popd
         overall=1
         continue

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -21,20 +21,6 @@ do
     then
         #grep ^ *.log
         echo "Retry failed, exit code" $rv
-        echo "======================================== $d Tests Failed. Start of logs ======================================="
-        log_file="hera.log"
-        if [ -f "$log_file" ]; then
-            cat "$log_file"
-        else
-            echo "Log file: ${log_file} does not exist."
-        fi
-        log_file="occ.log"
-        if [ -f "$log_file" ]; then
-            cat "$log_file"
-        else
-            echo "Log file: ${log_file} does not exist."
-        fi
-        echo "======================================== End of logs for $d test===================================================="
         popd
         overall=1
         continue

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -3,7 +3,7 @@ for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_rec
 do 
     echo ==== $d
     pushd tests/unittest/$d 
-    cp /home/runner/go/bin/mysqlworker .
+
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
     ./$d.test -test.v -test.parallel 1 
@@ -13,7 +13,7 @@ do
     then
         echo "Retrying" $d
         echo "exit code" $rv 
-        ./$d.test -test.v
+        ./$d.test -test.v -test.parallel 1
         rv=$?
         grep -E '(FAIL|PASS)' -A1 *.log
     fi

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -21,6 +21,20 @@ do
     then
         #grep ^ *.log
         echo "Retry failed, exit code" $rv
+        echo "======================================== $d Tests Failed. Start of logs ======================================="
+        log_file="hera.log"
+        if [ -f "$log_file" ]; then
+            cat "$log_file"
+        else
+            echo "Log file: ${log_file} does not exist."
+        fi
+        log_file="occ.log"
+        if [ -f "$log_file" ]; then
+            cat "$log_file"
+        else
+            echo "Log file: ${log_file} does not exist."
+        fi
+        echo "======================================== End of logs for $d test=================================================="
         popd
         overall=1
         continue

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -6,14 +6,14 @@ do
 
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
-    ./$d.test -test.v -test.parallel 1
+    ./$d.test -test.v
     rv=$?
     grep -E '(FAIL|PASS)' -A1 *.log
     if [ 0 != $rv ]
     then
         echo "Retrying" $d
         echo "exit code" $rv 
-        ./$d.test -test.v -test.parallel 1
+        ./$d.test -test.v
         rv=$?
         grep -E '(FAIL|PASS)' -A1 *.log
     fi

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -3,7 +3,7 @@ for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_rec
 do 
     echo ==== $d
     pushd tests/unittest/$d 
-
+    cp /home/runner/go/bin/mysqlworker .
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
     ./$d.test -test.v

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -1,19 +1,19 @@
 overall=0
-for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_recycle|log_checker_initdb|testutil|rac_maint|mysql_direct|failover)'`
+for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_recycle|log_checker_initdb|testutil|rac_maint|mysql_direct|failover|coordinator_sharding_with_scuttleid)'`
 do 
     echo ==== $d
     pushd tests/unittest/$d 
 
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
-    ./$d.test -test.v -test.parallel 1 
+    ./$d.test -test.v
     rv=$?
     grep -E '(FAIL|PASS)' -A1 *.log
     if [ 0 != $rv ]
     then
         echo "Retrying" $d
         echo "exit code" $rv 
-        ./$d.test -test.v -test.parallel 1
+        ./$d.test -test.v
         rv=$?
         grep -E '(FAIL|PASS)' -A1 *.log
     fi

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -6,7 +6,7 @@ do
     cp /home/runner/go/bin/mysqlworker .
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
-    ./$d.test -test.v
+    ./$d.test -test.v -test.parallel 1 
     rv=$?
     grep -E '(FAIL|PASS)' -A1 *.log
     if [ 0 != $rv ]

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -1,19 +1,19 @@
 overall=0
-for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_recycle|log_checker_initdb|testutil|rac_maint|mysql_direct|failover|coordinator_sharding_with_scuttleid)'`
+for d in `ls -F tests/unittest | grep /$ | sed -e "s,/,," | egrep -v '(mysql_recycle|log_checker_initdb|testutil|rac_maint|mysql_direct|failover)'`
 do 
     echo ==== $d
     pushd tests/unittest/$d 
 
     rm -f *.log 
     $GOROOT/bin/go test -c github.com/paypal/hera/tests/unittest/$d 
-    ./$d.test -test.v
+    ./$d.test -test.v -test.parallel 1
     rv=$?
     grep -E '(FAIL|PASS)' -A1 *.log
     if [ 0 != $rv ]
     then
         echo "Retrying" $d
         echo "exit code" $rv 
-        ./$d.test -test.v
+        ./$d.test -test.v -test.parallel 1
         rv=$?
         grep -E '(FAIL|PASS)' -A1 *.log
     fi

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -21,7 +21,7 @@ do
     then
         #grep ^ *.log
         echo "Retry failed, exit code" $rv
-        ls -al
+        echo "======================================== $d Tests Failed. Start of logs ======================================="
         log_file="hera.log"
         if [ -f "$log_file" ]; then
             cat "$log_file"
@@ -34,6 +34,7 @@ do
         else
             echo "Log file: ${log_file} does not exist."
         fi
+        echo "======================================== End of logs for $d test===================================================="
         popd
         overall=1
         continue

--- a/tests/unittest/testutil/setup.go
+++ b/tests/unittest/testutil/setup.go
@@ -201,7 +201,7 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 		for {
 			err := DBDirect("select 1", "127.0.0.1", dbName /*"heratestdb"*/, MySQL)
 			if err != nil {
-				time.Sleep(1 * time.Second)
+				time.Sleep(2 * time.Second)
 				logger.GetLogger().Log(logger.Debug, "waiting for mysql server to come up "+ipBuf.String()+" "+dockerName)
 				fmt.Printf("waiting for db to come up %d %s\n", waitLoop, err.Error())
 				waitLoop++
@@ -210,7 +210,7 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 				break
 			}
 		}
-
+                fmt.Printf("DB server started...\n")
 		q := "CREATE USER 'appuser'@'%' IDENTIFIED BY '1-testDb'"
 		err := DBDirect(q, ipBuf.String(), dbName, MySQL)
 		if err != nil {

--- a/tests/unittest/testutil/setup.go
+++ b/tests/unittest/testutil/setup.go
@@ -43,7 +43,7 @@ type DBType int
 const (
 	Oracle DBType = iota
 	MySQL
-	PostgreSQL
+	PostgreSQL 
 )
 
 type mux struct {
@@ -94,7 +94,7 @@ func (m *mux) setupWorkdir() {
 
 func (m *mux) setupConfig() error {
 	// opscfg
-	for k, v := range m.opscfg {
+	for k,v := range m.opscfg {
 		m.appcfg[k] = v
 	}
 	if m.wType == MySQLWorker {
@@ -149,7 +149,7 @@ func doBuildAndSymlink(binname string) {
 	var err error
 	_, err = os.Stat(binname)
 	if err != nil {
-		binpath := os.Getenv("GOPATH") + "/bin/" + binname
+		binpath := os.Getenv("GOPATH")+"/bin/"+binname
 		_, err = os.Stat(binpath)
 		if err != nil {
 			srcname := binname
@@ -199,17 +199,19 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 		os.Setenv("password", "1-testDb")
 		waitLoop := 1
 		for {
-			err := DBDirect("select 1", "127.0.0.1", dbName /*"heratestdb"*/, MySQL)
+			err := DBDirect("select 1", "127.0.0.1", dbName/*"heratestdb"*/, MySQL)
 			if err != nil {
-				time.Sleep(2 * time.Second)
+				time.Sleep(1 * time.Second)
 				logger.GetLogger().Log(logger.Debug, "waiting for mysql server to come up "+ipBuf.String()+" "+dockerName)
-				fmt.Printf("waiting for db to come up %d %s\n", waitLoop, err.Error())
+				fmt.Printf("waiting for db to come up %d %s\n",waitLoop, err.Error())
 				waitLoop++
 				continue
 			} else {
 				break
 			}
 		}
+
+
 		q := "CREATE USER 'appuser'@'%' IDENTIFIED BY '1-testDb'"
 		err := DBDirect(q, ipBuf.String(), dbName, MySQL)
 		if err != nil {
@@ -264,7 +266,7 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 		os.Setenv("postgresql_ip", ipBuf.String())
 
 		return ipBuf.String()
-	}
+	} 
 	return ""
 }
 
@@ -311,7 +313,7 @@ func DBDirect(query string, ip string, dbName string, dbType DBType) error {
 	}
 	db0.SetMaxIdleConns(0)
 	dbs[ip+dbName] = db0
-	ctx, _ := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 	conn0, err := db0.Conn(ctx)
 	if err != nil {
 		return err
@@ -382,10 +384,10 @@ func (m *mux) StartServer() error {
 			ip := MakeDB("postgres22", "heratestdb", PostgreSQL)
 			os.Setenv("TWO_TASK", ip+"/heratestdb?connect_timeout=60&sslmode=disable")
 			twoTask := os.Getenv("TWO_TASK")
-			os.Setenv("TWO_TASK_0", twoTask)
-			os.Setenv("TWO_TASK_1", twoTask)
+			os.Setenv ("TWO_TASK_0", twoTask)
+			os.Setenv ("TWO_TASK_1", twoTask)
 			twoTask1 := os.Getenv("TWO_TASK")
-			fmt.Println("TWO_TASK_1: ", twoTask1)
+			fmt.Println ("TWO_TASK_1: ", twoTask1)
 		}
 	}
 
@@ -398,7 +400,7 @@ func (m *mux) StartServer() error {
 	}()
 
 	// wait 10 seconds for mux to come up
-	toWait := 60
+	toWait := 20
 	for {
 		acpt, err := StatelogGetField(2)
 		if err == nil || err == INCOMPLETE {

--- a/tests/unittest/testutil/setup.go
+++ b/tests/unittest/testutil/setup.go
@@ -43,7 +43,7 @@ type DBType int
 const (
 	Oracle DBType = iota
 	MySQL
-	PostgreSQL 
+	PostgreSQL
 )
 
 type mux struct {
@@ -94,7 +94,7 @@ func (m *mux) setupWorkdir() {
 
 func (m *mux) setupConfig() error {
 	// opscfg
-	for k,v := range m.opscfg {
+	for k, v := range m.opscfg {
 		m.appcfg[k] = v
 	}
 	if m.wType == MySQLWorker {
@@ -149,7 +149,7 @@ func doBuildAndSymlink(binname string) {
 	var err error
 	_, err = os.Stat(binname)
 	if err != nil {
-		binpath := os.Getenv("GOPATH")+"/bin/"+binname
+		binpath := os.Getenv("GOPATH") + "/bin/" + binname
 		_, err = os.Stat(binpath)
 		if err != nil {
 			srcname := binname
@@ -199,18 +199,17 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 		os.Setenv("password", "1-testDb")
 		waitLoop := 1
 		for {
-			err := DBDirect("select 1", "127.0.0.1", dbName/*"heratestdb"*/, MySQL)
+			err := DBDirect("select 1", "127.0.0.1", dbName /*"heratestdb"*/, MySQL)
 			if err != nil {
 				time.Sleep(1 * time.Second)
 				logger.GetLogger().Log(logger.Debug, "waiting for mysql server to come up "+ipBuf.String()+" "+dockerName)
-				fmt.Printf("waiting for db to come up %d %s\n",waitLoop, err.Error())
+				fmt.Printf("waiting for db to come up %d %s\n", waitLoop, err.Error())
 				waitLoop++
 				continue
 			} else {
 				break
 			}
 		}
-
 
 		q := "CREATE USER 'appuser'@'%' IDENTIFIED BY '1-testDb'"
 		err := DBDirect(q, ipBuf.String(), dbName, MySQL)
@@ -266,7 +265,7 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 		os.Setenv("postgresql_ip", ipBuf.String())
 
 		return ipBuf.String()
-	} 
+	}
 	return ""
 }
 
@@ -313,7 +312,7 @@ func DBDirect(query string, ip string, dbName string, dbType DBType) error {
 	}
 	db0.SetMaxIdleConns(0)
 	dbs[ip+dbName] = db0
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 60*time.Second)
 	conn0, err := db0.Conn(ctx)
 	if err != nil {
 		return err
@@ -384,10 +383,10 @@ func (m *mux) StartServer() error {
 			ip := MakeDB("postgres22", "heratestdb", PostgreSQL)
 			os.Setenv("TWO_TASK", ip+"/heratestdb?connect_timeout=60&sslmode=disable")
 			twoTask := os.Getenv("TWO_TASK")
-			os.Setenv ("TWO_TASK_0", twoTask)
-			os.Setenv ("TWO_TASK_1", twoTask)
+			os.Setenv("TWO_TASK_0", twoTask)
+			os.Setenv("TWO_TASK_1", twoTask)
 			twoTask1 := os.Getenv("TWO_TASK")
-			fmt.Println ("TWO_TASK_1: ", twoTask1)
+			fmt.Println("TWO_TASK_1: ", twoTask1)
 		}
 	}
 
@@ -400,7 +399,7 @@ func (m *mux) StartServer() error {
 	}()
 
 	// wait 10 seconds for mux to come up
-	toWait := 20
+	toWait := 60
 	for {
 		acpt, err := StatelogGetField(2)
 		if err == nil || err == INCOMPLETE {

--- a/tests/unittest/testutil/setup.go
+++ b/tests/unittest/testutil/setup.go
@@ -210,7 +210,6 @@ func MakeDB(dockerName string, dbName string, dbType DBType) (ip string) {
 				break
 			}
 		}
-                fmt.Printf("DB server started...\n")
 		q := "CREATE USER 'appuser'@'%' IDENTIFIED BY '1-testDb'"
 		err := DBDirect(q, ipBuf.String(), dbName, MySQL)
 		if err != nil {

--- a/tests/unittest/testutil/util.go
+++ b/tests/unittest/testutil/util.go
@@ -7,13 +7,14 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/paypal/hera/lib"
+	"github.com/paypal/hera/utility/logger"
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
-
-	"github.com/paypal/hera/utility/logger"
 )
 
 var (
@@ -84,7 +85,7 @@ func BackupAndClear(logbasename, grpName string) {
 			break
 		}
 	}
-	logname := logbasename+".log"
+	logname := logbasename + ".log"
 	/* nowStr := time.Now().Format("15:04:05.000000")
 	f, err := os.OpenFile(logname, os.O_APPEND, 0666)
 	if err == nil {
@@ -105,11 +106,11 @@ func BackupAndClear(logbasename, grpName string) {
 }
 
 func RunMysql(sql string) (string, error) {
-        cmd := exec.Command("mysql","-h",os.Getenv("mysql_ip"),"-p1-testDb","-uroot", "heratestdb")
-        cmd.Stdin = strings.NewReader(sql)
-        var cmdOutBuf bytes.Buffer
-        cmd.Stdout = &cmdOutBuf
-        cmd.Run()
+	cmd := exec.Command("mysql", "-h", os.Getenv("mysql_ip"), "-p1-testDb", "-uroot", "heratestdb")
+	cmd.Stdin = strings.NewReader(sql)
+	var cmdOutBuf bytes.Buffer
+	cmd.Stdout = &cmdOutBuf
+	cmd.Run()
 	return cmdOutBuf.String(), nil
 }
 
@@ -179,4 +180,49 @@ func RegexCountFile(regex string, filename string) int {
 	}
 	//fmt.Println("DONE searching "+regex)
 	return count
+}
+
+func GetHostname() string {
+	hostname, err := os.Hostname()
+
+	if err != nil {
+		hostname = "127.0.0.1"
+	}
+	return hostname
+}
+
+func ComputeScuttleId(shardKey interface{}, maxScuttles string) (uint64, error) {
+	maxScuttlesVal, _ := strconv.ParseUint(maxScuttles, 10, 64)
+	logger.GetLogger().Log(logger.Info, fmt.Sprintf("ComputeScuttleId: Max scuttles value: %d", maxScuttlesVal))
+	switch keyType := shardKey.(type) {
+	case string:
+		keyStr := shardKey.(string)
+		//keyStr, ok := key0.(string)
+		key := uint64(lib.Murmur3([]byte(keyStr)))
+		return key % maxScuttlesVal, nil
+	case int:
+		bytes := make([]byte, 8)
+		keyNum, _ := shardKey.(int)
+		keyNumValue := uint64(keyNum)
+		for i := 0; i < 8; i++ {
+			bytes[i] = byte(keyNumValue & 0xFF)
+			keyNumValue >>= 8
+		}
+		key := uint64(lib.Murmur3(bytes))
+		return key % maxScuttlesVal, nil
+	case int64:
+		bytes := make([]byte, 8)
+		keyNum := shardKey.(uint64)
+		//keyNum, ok := key0.(uint64)
+		for i := 0; i < 8; i++ {
+			bytes[i] = byte(keyNum & 0xFF)
+			keyNum >>= 8
+		}
+		key := uint64(lib.Murmur3(bytes))
+		return key % maxScuttlesVal, nil
+	default:
+		logger.GetLogger().Log(logger.Info, fmt.Sprintf("Provided incorrect shardkey type: %v for tests for shard-key: %v", keyType, shardKey))
+		return 0, errors.New(fmt.Sprintf("Provided incorrect shardkey type: %v for tests for shard-key: %v", keyType, shardKey))
+	}
+	return 0, errors.New(fmt.Sprintf("Failed to compute scuttle ID for shardKey: %v", shardKey))
 }

--- a/tests/unittest/testutil/util.go
+++ b/tests/unittest/testutil/util.go
@@ -7,14 +7,13 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/paypal/hera/lib"
-	"github.com/paypal/hera/utility/logger"
 	"os"
 	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
+
+	"github.com/paypal/hera/utility/logger"
 )
 
 var (
@@ -85,7 +84,7 @@ func BackupAndClear(logbasename, grpName string) {
 			break
 		}
 	}
-	logname := logbasename + ".log"
+	logname := logbasename+".log"
 	/* nowStr := time.Now().Format("15:04:05.000000")
 	f, err := os.OpenFile(logname, os.O_APPEND, 0666)
 	if err == nil {
@@ -106,11 +105,11 @@ func BackupAndClear(logbasename, grpName string) {
 }
 
 func RunMysql(sql string) (string, error) {
-	cmd := exec.Command("mysql", "-h", os.Getenv("mysql_ip"), "-p1-testDb", "-uroot", "heratestdb")
-	cmd.Stdin = strings.NewReader(sql)
-	var cmdOutBuf bytes.Buffer
-	cmd.Stdout = &cmdOutBuf
-	cmd.Run()
+        cmd := exec.Command("mysql","-h",os.Getenv("mysql_ip"),"-p1-testDb","-uroot", "heratestdb")
+        cmd.Stdin = strings.NewReader(sql)
+        var cmdOutBuf bytes.Buffer
+        cmd.Stdout = &cmdOutBuf
+        cmd.Run()
 	return cmdOutBuf.String(), nil
 }
 
@@ -180,49 +179,4 @@ func RegexCountFile(regex string, filename string) int {
 	}
 	//fmt.Println("DONE searching "+regex)
 	return count
-}
-
-func GetHostname() string {
-	hostname, err := os.Hostname()
-
-	if err != nil {
-		hostname = "127.0.0.1"
-	}
-	return hostname
-}
-
-func ComputeScuttleId(shardKey interface{}, maxScuttles string) (uint64, error) {
-	maxScuttlesVal, _ := strconv.ParseUint(maxScuttles, 10, 64)
-	logger.GetLogger().Log(logger.Info, fmt.Sprintf("ComputeScuttleId: Max scuttles value: %d", maxScuttlesVal))
-	switch keyType := shardKey.(type) {
-	case string:
-		keyStr := shardKey.(string)
-		//keyStr, ok := key0.(string)
-		key := uint64(lib.Murmur3([]byte(keyStr)))
-		return key % maxScuttlesVal, nil
-	case int:
-		bytes := make([]byte, 8)
-		keyNum, _ := shardKey.(int)
-		keyNumValue := uint64(keyNum)
-		for i := 0; i < 8; i++ {
-			bytes[i] = byte(keyNumValue & 0xFF)
-			keyNumValue >>= 8
-		}
-		key := uint64(lib.Murmur3(bytes))
-		return key % maxScuttlesVal, nil
-	case int64:
-		bytes := make([]byte, 8)
-		keyNum := shardKey.(uint64)
-		//keyNum, ok := key0.(uint64)
-		for i := 0; i < 8; i++ {
-			bytes[i] = byte(keyNum & 0xFF)
-			keyNum >>= 8
-		}
-		key := uint64(lib.Murmur3(bytes))
-		return key % maxScuttlesVal, nil
-	default:
-		logger.GetLogger().Log(logger.Info, fmt.Sprintf("Provided incorrect shardkey type: %v for tests for shard-key: %v", keyType, shardKey))
-		return 0, errors.New(fmt.Sprintf("Provided incorrect shardkey type: %v for tests for shard-key: %v", keyType, shardKey))
-	}
-	return 0, errors.New(fmt.Sprintf("Failed to compute scuttle ID for shardKey: %v", shardKey))
 }


### PR DESCRIPTION
1.  Compare the scuttle_id value from the request bind-in param, with the computed logical bucket id from the shard key. This Verification works for DML queries
2.  For Read/Select queries this verification doesn't happen.
3. If the Application set ShardID via SetShard then this verification doesn't apply. It applies in the case of shard-key auto-discovery mode.