### PR TITLE
Sql id changes

### DIFF
--- a/worker/cppworker/worker/OCCChild.h
+++ b/worker/cppworker/worker/OCCChild.h
@@ -427,6 +427,10 @@ private:
 	// stores into buffer (overwrites)
 	int get_oracle_error(int rc, std::string& buffer);
 
+	// frees oci stmt handle and logs messages
+	// if the hndlp is NULL, then do nothing and return true
+	// returns false if error was detected
+	// Use this only for stmt handle. Use DO_OCI_HANDLE_FREE to free other handles
 	bool do_oci_stmt_release(OCIStmt *&stmthp, LogLevelEnum level);
 	// use the #define DO_OCI_HANDLE_FREE()
 	// it'll only be in the .cpp since this is private

--- a/worker/cppworker/worker/OCCChild.h
+++ b/worker/cppworker/worker/OCCChild.h
@@ -427,6 +427,7 @@ private:
 	// stores into buffer (overwrites)
 	int get_oracle_error(int rc, std::string& buffer);
 
+	bool do_oci_stmt_release(OCIStmt *&stmthp, LogLevelEnum level);
 	// use the #define DO_OCI_HANDLE_FREE()
 	// it'll only be in the .cpp since this is private
 	// frees oci resources and logs messages

--- a/worker/cppworker/worker/OCCChild.h
+++ b/worker/cppworker/worker/OCCChild.h
@@ -278,6 +278,7 @@ private:
 	std::string m_orig_query_hash;
 	int bits_to_match; // Sampled Bind Hash logging. Sampling ratio (1:pow(2,bits_to_match)). Default 1 (Sampling ratio 1:2)
 	unsigned long long int bit_mask; // Compute based on bits_to_match
+	std::string sql_id_str;
 
 public:
 	// need to pass in a server socket which is already bound to the correct port

--- a/worker/cppworker/worker/Worker.cpp
+++ b/worker/cppworker/worker/Worker.cpp
@@ -443,6 +443,8 @@ void Worker::run()
 				client_session.start_session("API", m_cal_client_session_name);
 				client_session.get_session_transaction()->AddData("worker_pid", getpid());
 				client_session.get_session_transaction()->AddData("sid", m_sid);
+				client_session.get_session_transaction()->AddData("rac_id", m_connected_id);
+				client_session.get_session_transaction()->AddData("db_uname", m_db_uname);
 				client_session.set_status(CAL::TRANS_OK); // internal queries' error overwrite status so reset it.
 			}
 			WRITE_LOG_ENTRY(logfile, LOG_VERBOSE, "Session started");


### PR DESCRIPTION
Changes to retrieve sql_id from Oracle. This will be added as part of the EXEC CAL message. It would be easier to map SQLHash -> Oracle sql_id

Note: The flag (OCI_PREP2_GET_SQL_ID) used is newly introduced and is not backward compatible with the 11g client. 