### PR TITLE
CLIENT_INFO with just the application name

### DIFF
--- a/lib/coordinator.go
+++ b/lib/coordinator.go
@@ -944,13 +944,15 @@ func (crd *Coordinator) doRequest(ctx context.Context, worker *WorkerClient, req
 			
 			var ns []*netstring.Netstring
 			if GetConfig().EnableCmdClientInfoToWorker {
-				logger.GetLogger().Log(logger.Verbose, len(crd.poolName), len(crd.clientPoolStack))
-				if crd.poolName == "null" {
+				// logger.GetLogger().Log(logger.Verbose, len(crd.poolName), len(crd.clientPoolStack))
+				logger.GetLogger().Log(logger.Verbose, len(crd.poolName))
+				if crd.poolName == "null" || len(crd.poolName) == 0 {
 					crd.poolName = "unset"
 				}
-				clientInfoMessage := fmt.Sprintf("%s|%s", crd.poolName, crd.clientPoolStack)
+				// clientInfoMessage := fmt.Sprintf("%s|%s", crd.poolName, crd.clientPoolStack)
+				clientInfoMessage := crd.poolName
 				logger.GetLogger().Log(logger.Verbose, "GetConfig().EnableCmdClientInfoToWorker:", GetConfig().EnableCmdClientInfoToWorker)
-				logger.GetLogger().Log(logger.Verbose, clientInfoMessage)
+				logger.GetLogger().Log(logger.Verbose, "clientInfoMessage:", clientInfoMessage)
 				clientInfo := netstring.NewNetstringFrom(common.CmdClientInfo, []byte(clientInfoMessage))
 				if !request.IsComposite() {
 					ns = make([]*netstring.Netstring, 3)

--- a/tests/unittest/client_info_to_worker_enabled/main_test.go
+++ b/tests/unittest/client_info_to_worker_enabled/main_test.go
@@ -82,7 +82,7 @@ func TestClientInfoToWorkerHappyPath(t *testing.T) {
 	}
 	rows.Close()
 	
-	if testutil.RegexCountFile("clientInfoMessage:testApplication", "hera.log") < 1 {
+	if testutil.RegexCountFile("clientInfoMessage: testApplication", "hera.log") < 1 {
 		t.Fatalf("Error: should have sent CmdClientInfoToWorker to worker")
 	}
 
@@ -129,12 +129,16 @@ func TestClientInfoToWorkerMissingClientInfo(t *testing.T) {
 	}
 	rows.Close()
 
-	if testutil.RegexCountFile("clientInfoMessage:unset", "hera.log") < 1 {
+	if testutil.RegexCountFile("clientInfoMessage: unset", "hera.log") < 1 {
 		t.Fatalf("Error: mux should have set the poolName to unset")
 	}
 	
 	if testutil.RegexCountFile("clientApplication: unset", "hera.log") < 1 {
 		t.Fatalf("Error: should have got unset from mux")
+	}
+
+	if testutil.RegexCountFile("CLIENT_INFO_MUX.*testApplication.*", "cal.log") < 1 {
+		t.Fatalf("Error: Mux should not have processed CmdClientInfo")
 	}
 
 	cancel()
@@ -172,7 +176,7 @@ func TestClientInfoToWorkerMissingPoolName(t *testing.T) {
 	}
 	rows.Close()
 
-	if testutil.RegexCountFile("clientInfoMessage:unset", "hera.log") < 1 {
+	if testutil.RegexCountFile("clientInfoMessage: unset", "hera.log") < 1 {
 		t.Fatalf("Error: mux should have set the poolName to unset")
 	}
 	
@@ -180,7 +184,7 @@ func TestClientInfoToWorkerMissingPoolName(t *testing.T) {
 		t.Fatalf("Error: should have got unset from mux")
 	}
 	
-	if testutil.RegexCountFile("CLIENT_INFO_MUX.*testApplication.*", "cal.log") < 2 {
+	if testutil.RegexCountFile("CLIENT_INFO_MUX.*", "cal.log") < 2 {
 		t.Fatalf("Error: Mux should rename the CLIENT_INFO event")
 	}
 

--- a/tests/unittest/client_info_to_worker_enabled/main_test.go
+++ b/tests/unittest/client_info_to_worker_enabled/main_test.go
@@ -82,16 +82,12 @@ func TestClientInfoToWorkerHappyPath(t *testing.T) {
 	}
 	rows.Close()
 	
-	if testutil.RegexCountFile("testApplication|testApplication:testURL*CalThreadId=0*TopLevelTxnStartTime=18840b76115*Host=localhost*pid=100", "hera.log") < 1 {
+	if testutil.RegexCountFile("clientInfoMessage:testApplication", "hera.log") < 1 {
 		t.Fatalf("Error: should have sent CmdClientInfoToWorker to worker")
 	}
 
 	if testutil.RegexCountFile("clientApplication: testApplication", "hera.log") < 1 {
 		t.Fatalf("Error: CmdProcessor should have processed CmdClientInfo")
-	}
-
-	if testutil.RegexCountFile("poolStack: testApplication.*", "hera.log") < 1 {
-		t.Fatalf("Error: CmdProcessor should have proceesed CmdClientInfo")
 	}
 
 	if testutil.RegexCountFile("CLIENT_INFO_MUX.*testApplication.*", "cal.log") < 1 {
@@ -132,17 +128,13 @@ func TestClientInfoToWorkerMissingClientInfo(t *testing.T) {
 		t.Fatalf("Expected 1 row")
 	}
 	rows.Close()
+
+	if testutil.RegexCountFile("clientInfoMessage:unset", "hera.log") < 1 {
+		t.Fatalf("Error: mux should have set the poolName to unset")
+	}
 	
-	if testutil.RegexCountFile("len clientApplication: 0", "hera.log") < 1 {
-		t.Fatalf("Error: should have sent empty clientApplication details to worker")
-	}
-
-	if testutil.RegexCountFile("len poolStack: 0", "hera.log") < 1 {
-		t.Fatalf("Error: should have sent empty poolStack details to worker")
-	}
-
-	if testutil.RegexCountFile("clientApplication: unknown", "hera.log") < 1 {
-		t.Fatalf("Error: CmdProcessor should have renamed the missing poolName to unknown")
+	if testutil.RegexCountFile("clientApplication: unset", "hera.log") < 1 {
+		t.Fatalf("Error: should have got unset from mux")
 	}
 
 	cancel()
@@ -179,23 +171,15 @@ func TestClientInfoToWorkerMissingPoolName(t *testing.T) {
 		t.Fatalf("Expected 1 row")
 	}
 	rows.Close()
+
+	if testutil.RegexCountFile("clientInfoMessage:unset", "hera.log") < 1 {
+		t.Fatalf("Error: mux should have set the poolName to unset")
+	}
 	
-	if testutil.RegexCountFile("len clientApplication: 0", "hera.log") < 2 {
-		t.Fatalf("Error: should have sent empty clientApplication details to worker")
+	if testutil.RegexCountFile("clientApplication: unset", "hera.log") < 1 {
+		t.Fatalf("Error: should have got unset from mux")
 	}
-
-	if testutil.RegexCountFile("len poolStack: 93", "hera.log") < 1 {
-		t.Fatalf("Error: CmdProcessor should have proceesed CmdClientInfo")
-	}
-
-	if testutil.RegexCountFile("clientApplication: unknown", "hera.log") < 2 {
-		t.Fatalf("Error: CmdProcessor should have renamed the missing poolName to unknown")
-	}
-
-	if testutil.RegexCountFile("poolStack: testApplication.*", "hera.log") < 2 {
-		t.Fatalf("Error: CmdProcessor should have proceesed CmdClientInfo")
-	}
-
+	
 	if testutil.RegexCountFile("CLIENT_INFO_MUX.*testApplication.*", "cal.log") < 2 {
 		t.Fatalf("Error: Mux should rename the CLIENT_INFO event")
 	}
@@ -204,57 +188,4 @@ func TestClientInfoToWorkerMissingPoolName(t *testing.T) {
 	conn.Close()
 
 	logger.GetLogger().Log(logger.Debug, "TestClientInfoToWorkerMissingPoolName done +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
-}
-
-
-func TestClientInfoToWorkerMissingPoolStack(t *testing.T) {
-	logger.GetLogger().Log(logger.Debug, "TestClientInfoToWorkerMissingPoolStack begin +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
-	time.Sleep(5*time.Second)
-	shard := 0
-	db, err := sql.Open("heraloop", fmt.Sprintf("%d:0:0", shard))
-	if err != nil {
-		t.Fatal("Error starting Mux:", err)
-		return
-	}
-	db.SetMaxIdleConns(0)
-	defer db.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	conn, err := db.Conn(ctx);
-	if err != nil {
-		t.Fatalf("Error getting connection %s\n", err.Error())
-	}
-	mux := gosqldriver.InnerConn(conn)
-	mux.SetCalCorrID("583f5e4a2758e")
-	err = mux.SetClientInfoWithPoolStack("testApplication4", "localhost", "")
-	if err != nil {
-		t.Fatalf("Unable to set CLIENT_INFO")
-	}
-	rows, _ := conn.QueryContext(ctx, "SELECT version()")
-	// rows, _ := stmt.Query(1)
-	if !rows.Next() {
-		t.Fatalf("Expected 1 row")
-	}
-	rows.Close()
-
-	if testutil.RegexCountFile("testApplication4|", "hera.log") < 1 {
-		t.Fatalf("Error: should have sent CmdClientInfoToWorker to worker")
-	}
-
-	if testutil.RegexCountFile("clientApplication: testApplication4", "hera.log") < 1 {
-		t.Fatalf("Error: CmdProcessor should have processed CmdClientInfo")
-	}
-	
-	if testutil.RegexCountFile("len poolStack: 0", "hera.log") < 2 {
-		t.Fatalf("Error: should have sent empty poolStack details to worker")
-	}
-
-	if testutil.RegexCountFile("CLIENT_INFO_MUX.*testApplication.*", "cal.log") < 3 {
-		t.Fatalf("Error: Mux should rename the CLIENT_INFO event")
-	}
-
-
-	cancel()
-	conn.Close()
-
-	logger.GetLogger().Log(logger.Debug, "TestClientInfoToWorkerMissingPoolStack done +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\n")
 }

--- a/worker/cppworker/worker/OCCChild.cpp
+++ b/worker/cppworker/worker/OCCChild.cpp
@@ -1330,7 +1330,14 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 				m_writer->write(OCC_MARKDOWN);
 				break;
 			}
-			std::string poolStack = _line;
+			std::string client_info = _line;
+			if (client_info.length() == 0)
+			{
+				client_info = "unknown";
+			}
+			WRITE_LOG_ENTRY(logfile, LOG_VERBOSE, "Client info: %s", client_info.c_str());
+			CalEvent e(CAL::EVENT_TYPE_CLIENT_INFO, client_info, CAL::TRANS_OK);
+			/* std::string poolStack = _line;
 			std::string client_info;
 
 			StringUtil::tokenize(poolStack, client_info, '|');
@@ -1344,7 +1351,7 @@ int OCCChild::handle_command(const int _cmd, std::string &_line)
 				WRITE_LOG_ENTRY(logfile, LOG_DEBUG, "set poolStack: %s", poolStack.c_str());
 				CalTransaction::SetParentStack(poolStack, std::string("CLIENT_INFO"));
 			}
-			e.AddPoolStack();
+			e.AddPoolStack(); */
 			// CalEvent e(CAL::EVENT_TYPE_CLIENT_INFO, client_info, CAL::TRANS_OK, poolStack);
 
 			if (cur_stmt != NULL)

--- a/worker/shared/cmdprocessor.go
+++ b/worker/shared/cmdprocessor.go
@@ -227,12 +227,8 @@ outloop:
 			logger.GetLogger().Log(logger.Verbose, "CmdClientInfo:", string(ns.Payload), string(ns.Serialized))
 		}
 		if len(string(ns.Payload)) > 0 {
-			logger.GetLogger().Log(logger.Verbose, "len clientApplication:", len(ns.Payload))
-			if len(ns.Payload) == 0 {
-				logger.GetLogger().Log(logger.Verbose, "clientApplication: unknown")
-			} else {
-				logger.GetLogger().Log(logger.Verbose, "clientApplication:", string(ns.Payload))
-			}
+			logger.GetLogger().Log(logger.Verbose, "len clientApplication:", len(string(ns.Payload)))
+			logger.GetLogger().Log(logger.Verbose, "clientApplication:", string(ns.Payload))
 			// splits := strings.Split(string(ns.Payload), "|")
 			// if (len(splits) == 2) {
 			// 	logger.GetLogger().Log(logger.Verbose, "len clientApplication:", len(splits[0]))
@@ -249,6 +245,8 @@ outloop:
 			// } else {
 			// 	logger.GetLogger().Log(logger.Debug, "CmdClientInfo: Payload not in expected Client&PoolStack format:", string(ns.Payload))
 			// }
+		} else {
+			logger.GetLogger().Log(logger.Verbose, "clientApplication: unknown")
 		}
 	case common.CmdPrepare, common.CmdPrepareV2, common.CmdPrepareSpecial:
 		cp.dedicated = true

--- a/worker/shared/cmdprocessor.go
+++ b/worker/shared/cmdprocessor.go
@@ -231,7 +231,7 @@ outloop:
 			if len(ns.Payload) == 0 {
 				logger.GetLogger().Log(logger.Verbose, "clientApplication: unknown")
 			} else {
-				logger.GetLogger().Log(logger.Verbose, "clientApplication: ", ns.Payload)
+				logger.GetLogger().Log(logger.Verbose, "clientApplication:", string(ns.Payload))
 			}
 			// splits := strings.Split(string(ns.Payload), "|")
 			// if (len(splits) == 2) {

--- a/worker/shared/cmdprocessor.go
+++ b/worker/shared/cmdprocessor.go
@@ -227,22 +227,28 @@ outloop:
 			logger.GetLogger().Log(logger.Verbose, "CmdClientInfo:", string(ns.Payload), string(ns.Serialized))
 		}
 		if len(string(ns.Payload)) > 0 {
-			splits := strings.Split(string(ns.Payload), "|")
-			if (len(splits) == 2) {
-				logger.GetLogger().Log(logger.Verbose, "len clientApplication:", len(splits[0]))
-				logger.GetLogger().Log(logger.Verbose, "len poolStack:", len(splits[1]))
-				if len(splits[0]) == 0 {
-					logger.GetLogger().Log(logger.Verbose, "clientApplication: unknown")
-				} else {
-					logger.GetLogger().Log(logger.Verbose, "clientApplication:", splits[0])
-				}
-				logger.GetLogger().Log(logger.Verbose, "poolStack:", splits[1])
-				//
-				// @TODO Add CLIENT_INFO event inside calSessionTxn
-				//
+			logger.GetLogger().Log(logger.Verbose, "len clientApplication:", len(ns.Payload))
+			if len(ns.Payload) == 0 {
+				logger.GetLogger().Log(logger.Verbose, "clientApplication: unknown")
 			} else {
-				logger.GetLogger().Log(logger.Debug, "CmdClientInfo: Payload not in expected Client&PoolStack format:", string(ns.Payload))
+				logger.GetLogger().Log(logger.Verbose, "clientApplication: ", ns.Payload)
 			}
+			// splits := strings.Split(string(ns.Payload), "|")
+			// if (len(splits) == 2) {
+			// 	logger.GetLogger().Log(logger.Verbose, "len clientApplication:", len(splits[0]))
+			// 	logger.GetLogger().Log(logger.Verbose, "len poolStack:", len(splits[1]))
+			// 	if len(splits[0]) == 0 {
+			// 		logger.GetLogger().Log(logger.Verbose, "clientApplication: unknown")
+			// 	} else {
+			// 		logger.GetLogger().Log(logger.Verbose, "clientApplication:", splits[0])
+			// 	}
+			// 	logger.GetLogger().Log(logger.Verbose, "poolStack:", splits[1])
+			// 	//
+			// 	// @TODO Add CLIENT_INFO event inside calSessionTxn
+			// 	//
+			// } else {
+			// 	logger.GetLogger().Log(logger.Debug, "CmdClientInfo: Payload not in expected Client&PoolStack format:", string(ns.Payload))
+			// }
 		}
 	case common.CmdPrepare, common.CmdPrepareV2, common.CmdPrepareSpecial:
 		cp.dedicated = true


### PR DESCRIPTION
Sample CLIENT_SESSION 
```
t21:43:57.05	API	CLIENT_SESSION
E21:43:57.05	CLIENT_INFO	testApplication	0
$1791863571	/*shard=0*/ SELECT inst_id, UPPER(status), status_time, UPPER(module) FROM pypl_occ_maint WHERE UPPER(machine) = :p1 and UPPER(module) in ( :p2, :p3 ) ORDER BY inst_id
A21:43:57.05	EXEC	1791863571	0	5.1	HOST=HAWA
A21:43:57.05	FETCH	1791863571	0	.2	HOST=HAWA&psize=0
T21:43:57.05	API	CLIENT_SESSION	0	6.1	corr_id_=NotSet&log_id_=18a25db32fa&worker_pid=409060&sid=763
```