### PR TITLE
enabling go vet with exceptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/godror/godror v0.26.3
-	github.com/lib/pq v1.10.3
+	github.com/lib/pq v1.10.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,14 +8,9 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/lib/pq v1.10.3 h1:v9QZf2Sn6AmjXtQeFpdoq/eaNtYP6IN+7lcrygsIAtg=
-github.com/lib/pq v1.10.3 h1:v9QZf2Sn6AmjXtQeFpdoq/eaNtYP6IN+7lcrygsIAtg=
-github.com/lib/pq v1.10.3/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.10.3/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/govet.sh
+++ b/govet.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# rebuilds are for developing this script
+if [ x$1 = xrebuild ]
+then
+    find . -name 'vet.log*' | xargs /bin/rm
+fi
+
+out=0
+# find directories with go source files
+for e in `find . -name '*.go' |sed -e 's,/[^/]*$,,'|sort -u`
+do 
+    (
+    d=`echo $e | sed -e 's,^..,,'`
+    cd $d
+    go vet -c=3 github.com/paypal/hera/$d 2> vet.log3 
+    rv=$?
+    if [ $rv -ne 0 ]
+    then
+        # remove line numbers
+        sed -e 's/^[0-9]*//;s/[.]go:[0-9]*:[0-9]*: /.go /' vet.log3 > vet.log2
+
+        # save the go vet output if we are rebuilding
+        if [ x$1 = xrebuild -a ! -e vet.log ]
+        then
+            cp vet.log{2,}
+        fi
+
+        # diff go vet output against dev commit vet.log
+        if [ ! -e vet.log ]
+        then
+            cat vet.log2
+            rvd=2
+        else
+            diff vet.log{,2}
+            rvd=$?
+        fi
+        if [ $rvd -ne 0 ]
+        then
+            echo $rvd rv-vet-diff $d
+            exit $rvd
+        fi
+    fi 
+    ) 
+    subRv=$?
+    if [ $subRv -ne 0 ]
+    then
+        out=$subRv
+    fi
+done
+
+if [ x$1 = xrebuild ]
+then
+    time ./govet.sh
+    out=$?
+    echo `date` "second pass complete for rebuild"
+fi
+
+echo $out overall go vet rv
+exit $out

--- a/tests/functionaltest/bind_eviction_tests/inclause_evict/vet.log
+++ b/tests/functionaltest/bind_eviction_tests/inclause_evict/vet.log
@@ -1,0 +1,33 @@
+# github.com/paypal/hera/tests/functionaltest/bind_eviction_tests/inclause_evict
+./main_test_disable.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./main_test_disable.go this return statement may be reached without using the cancel var defined on line 66
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	        defer conn.Close()
+	        defer cancel()
+./main_test_disable.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./main_test_disable.go this return statement may be reached without using the cancel var defined on line 107
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	        defer conn.Close()
+	        defer cancel()

--- a/tests/functionaltest/bind_eviction_tests/simple_evict/vet.log
+++ b/tests/functionaltest/bind_eviction_tests/simple_evict/vet.log
@@ -1,0 +1,33 @@
+# github.com/paypal/hera/tests/functionaltest/bind_eviction_tests/simple_evict
+./main_test_disable.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./main_test_disable.go this return statement may be reached without using the cancel var defined on line 66
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	 
+	        defer conn.Close()
+./main_test_disable.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./main_test_disable.go this return statement may be reached without using the cancel var defined on line 112
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	        defer conn.Close()
+	        // cancel must be called before conn.Close()

--- a/tests/functionaltest/bind_eviction_tests/util/vet.log
+++ b/tests/functionaltest/bind_eviction_tests/util/vet.log
@@ -1,0 +1,49 @@
+# github.com/paypal/hera/tests/functionaltest/bind_eviction_tests/util
+./dbops.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./dbops.go this return statement may be reached without using the cancel var defined on line 37
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	        defer conn.Close()
+	        defer cancel()
+./dbops.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./dbops.go this return statement may be reached without using the cancel var defined on line 84
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	        defer conn.Close()
+	        defer cancel()
+./dbops.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Println("Error creating context:", err)
+./dbops.go this return statement may be reached without using the cancel var defined on line 139
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Println("Error creating context:", err)
+	                return count
+	        }
+	        defer conn.Close()
+	        defer cancel()

--- a/tests/functionaltest/runall.sh
+++ b/tests/functionaltest/runall.sh
@@ -33,7 +33,7 @@ do
 
     $GOROOT/bin/go test -c .
 
-    retry=2
+    retry=4
     while [ $retry -ge 0 ]
     do
         ./$d.test -test.v 2>&1 | tee std.log

--- a/tests/functionaltest/testutil/vet.log
+++ b/tests/functionaltest/testutil/vet.log
@@ -1,0 +1,225 @@
+# github.com/paypal/hera/tests/functionaltest/testutil
+./setup.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+				dbs[ip+dbName] = db0
+			}
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		conn0, err := db0.Conn(ctx)
+		if err != nil {
+			return err
+./util.go the cancel function is not used on all paths (possible context leak)
+	        db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Println("Error creating context:", err)
+./util.go this return statement may be reached without using the cancel var defined on line 106
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Println("Error creating context:", err)
+	                return count
+	        }
+	        defer conn.Close()
+	        // cancel must be called before conn.Close()
+./util.go the cancel function is not used on all paths (possible context leak)
+	        //db.SetMaxIdleConns(0)
+	        defer db.Close()
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+./util.go this return statement may be reached without using the cancel var defined on line 193
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                return err
+	        }
+	        defer conn.Close()
+	        // cancel must be called before conn.Close()
+./util.go the cancel function is not used on all paths (possible context leak)
+	                return err
+	        }
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+./util.go this return statement may be reached without using the cancel var defined on line 242
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+	                return err
+	        }
+	
+	        //Insert a rac maintenance row
+./util.go the cancel function is not used on all paths (possible context leak)
+	                return err
+	        }
+	
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+./util.go this return statement may be reached without using the cancel var defined on line 288
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+	                return err
+	        }
+		 //Insert a rac maintenance row with no time
+	        txn, _ := conn.BeginTx(ctx, nil)
+./util.go the cancel function is not used on all paths (possible context leak)
+	        }
+	
+	        //Insert a rac maintenance row
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+./util.go this return statement may be reached without using the cancel var defined on line 338
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+	                return err
+	        }
+	        txn, _ := conn.BeginTx(ctx, nil)
+	        stmt, _ := txn.PrepareContext(ctx, "/*cmd*/insert into hera_maint (inst_id, status, status_time, module, machine) values (?,?,?,?,?)")
+./util.go fmt.Println call has possible formatting directive %s
+	        defer stmt.Close()
+	        _, err = stmt.Exec()
+	        if err != nil {
+	                fmt.Println ("Set autocommit to false: %s", err)
+	                return err
+	        }
+	        stmt, _ = tx.PrepareContext(ctx, dml)
+./util.go result of fmt.Errorf call not used
+	        fmt.Println ("Hostname: ", hostname);
+	        db, err := sql.Open("hera", hostname + ":31002")
+	        if err != nil {
+	                fmt.Errorf ("Error connection to go mux: %s", err)
+	                return err
+	        }
+	        db.SetMaxIdleConns(0)
+./util.go result of fmt.Errorf call not used
+	
+	        err = RunDML("DELETE from hera_maint")
+	        if err != nil {
+	                fmt.Errorf ("Error preparing test (delete table) %s\n", err.Error())
+	                return err
+	        }
+	
+./util.go result of fmt.Errorf call not used
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+	                return err
+	        }
+	
+./util.go result of fmt.Errorf call not used
+	        stmt, _ := txn.PrepareContext(ctx, "/*cmd*/insert into hera_maint (inst_id, status, status_time, module, machine) values (?,?,?,?,?)")
+	         _, err = stmt.Exec(0, status, time.Now().Unix()+diff_time, module , hostname)
+	        if err != nil {
+	        	fmt.Errorf ("Error executing sql rac insert statement %s\n", err.Error())
+	                return err
+	        }
+	
+./util.go result of fmt.Errorf call not used
+	        fmt.Println ("Hostname: ", hostname);
+	        db, err := sql.Open("hera", hostname + ":31002")
+	        if err != nil {
+	                fmt.Errorf ("Error connection to go mux: %s", err)
+	                return err
+	        }
+	        db.SetMaxIdleConns(0)
+./util.go result of fmt.Errorf call not used
+	
+	        err = RunDML("DELETE from hera_maint")
+	        if err != nil {
+	                fmt.Errorf ("Error preparing test (delete table) %s\n", err.Error())
+	                return err
+	        }
+	
+./util.go result of fmt.Errorf call not used
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+	                return err
+	        }
+		 //Insert a rac maintenance row with no time
+./util.go result of fmt.Errorf call not used
+	        stmt, _ := txn.PrepareContext(ctx, "/*cmd*/insert into hera_maint (inst_id, status, module, machine) values (?,?,?,?)")
+	         _, err = stmt.Exec(0, status, module , hostname)
+	        if err != nil {
+	                fmt.Errorf ("Error executing sql rac insert statement with empty time %s\n", err.Error())
+	                return err
+	        }
+	
+./util.go result of fmt.Errorf call not used
+		stmt, _ = txn.PrepareContext(ctx, "/*cmd*/insert into hera_maint (inst_id, status, status_time, module, machine) values (?,?,?,?,?)")
+	         _, err = stmt.Exec(0, status, time.Now().Unix()+diff_time, module , hostname)
+	        if err != nil {
+	                fmt.Errorf ("Error executing sql rac insert statement %s\n", err.Error())
+	                return err
+	        }
+	        err = txn.Commit()
+./util.go result of fmt.Errorf call not used
+	        fmt.Println ("Hostname: ", hostname);
+	        db, err := sql.Open("hera", hostname + ":31002")
+	        if err != nil {
+	                fmt.Errorf ("Error connection to go mux: %s", err)
+	                return err
+	        }
+	        db.SetMaxIdleConns(0)
+./util.go result of fmt.Errorf call not used
+	
+	        err = RunDML("DELETE from hera_maint")
+	        if err != nil {
+	                fmt.Errorf ("Error preparing test (delete table) %s\n", err.Error())
+	                return err
+	        }
+	
+./util.go result of fmt.Errorf call not used
+	        ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	        conn, err := db.Conn(ctx)
+	        if err != nil {
+	                fmt.Errorf ("Error getting connection %s\n", err.Error())
+	                return err
+	        }
+	        txn, _ := conn.BeginTx(ctx, nil)
+./util.go result of fmt.Errorf call not used
+	        stmt, _ := txn.PrepareContext(ctx, "/*cmd*/insert into hera_maint (inst_id, status, status_time, module, machine) values (?,?,?,?,?)")
+	         _, err = stmt.Exec(0, status, time.Now().Unix()+diff_time, module , hostname)
+	        if err != nil {
+	                fmt.Errorf ("Error executing sql rac insert statement with empty time %s\n", err.Error())
+	                return err
+	        }
+	        //Insert a rac maintenance row with no time
+./util.go result of fmt.Errorf call not used
+	        stmt, _ = txn.PrepareContext(ctx, "/*cmd*/insert into hera_maint (inst_id, status, module, machine) values (?,?,?,?)")
+	         _, err = stmt.Exec(0, status, module , hostname)
+	        if err != nil {
+	                fmt.Errorf ("Error executing sql rac insert statement %s\n", err.Error())
+	                return err
+	        }
+	        err = txn.Commit()
+./util.go result of fmt.Errorf call not used
+	    //fmt.Println ("Grep command in ExtractClientId: ", cmd)
+	    out, err := BashCmd(cmd)
+	    if (err != nil) {
+	        fmt.Errorf("Error occur when extracting client id: %s", out)
+	    }
+	    client := strings.TrimSpace (string(out))
+	    return client
+./util.go result of fmt.Errorf call not used
+	    //fmt.Println ("Grep command to extract worker Id: ", cmd)
+	    out, err := BashCmd(cmd)
+	    if (err != nil) {
+	        fmt.Errorf("Error occur when extracting worker id: %s", out)
+	    }
+	    file, err := os.Open("pids.tmp")
+	    if err != nil {

--- a/tests/mocksqlsrv/dummy/vet.log
+++ b/tests/mocksqlsrv/dummy/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/tests/mocksqlsrv/dummy
+./connection.go fmt.Sprintf format %d reads arg #1, but call has 0 args
+	          if err != nil {
+	               log.Fatal(err)
+	          } else if i != packetsize + HEADER_SIZE {
+	               log.Fatal(fmt.Sprintf("Wrote %d bytes"))
+	          }
+	
+	          /* Update remaining payload length and sequence_id. */

--- a/tests/mocksqlsrv/vet.log
+++ b/tests/mocksqlsrv/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/tests/mocksqlsrv
+./samplequeries.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	     // Test selects.
+	     selects(db, disp)
+	
+	     ctx, _ /*cancel*/ := context.WithTimeout(context.Background(), 10*time.Second)
+	     // ctx := context.Background()
+		conn, err := db.Conn(ctx)
+	

--- a/tests/unittest/failover/vet.log
+++ b/tests/unittest/failover/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/tests/unittest/failover
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	
+	func doCrud(conn *sql.Conn, id int, t* testing.T) (bool) {
+	
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	
+		//note := time.Now().Format("test note 2006-01-02j15:04:05.000 failover")
+		stmt, err := conn.PrepareContext(ctx, "drop table test_failover")

--- a/tests/unittest/failover3/vet.log
+++ b/tests/unittest/failover3/vet.log
@@ -1,0 +1,17 @@
+# github.com/paypal/hera/tests/unittest/failover3
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	}
+	
+	func commit(conn *sql.Conn, t* testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	        tx, err := conn.BeginTx(ctx, nil)
+	        if err != nil {
+	                t.Fatalf("Error begin tx %s\n", err.Error())
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	func doCrud(conn *sql.Conn, id int, t* testing.T) (bool) {
+		note := time.Now().Format("test note 2006-01-02j15:04:05.000 failover")
+	
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	
+		stmt, err := conn.PrepareContext(ctx, "create table test_failover ( id int, note varchar(55), autoI int not null auto_increment, primary key (autoI) )")
+		if err != nil {

--- a/tests/unittest/postgres_failover/vet.log
+++ b/tests/unittest/postgres_failover/vet.log
@@ -1,0 +1,25 @@
+# github.com/paypal/hera/tests/unittest/postgres_failover
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	}
+	
+	func commit(conn *sql.Conn, t* testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		tx, err := conn.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("Error begin tx %s\n", err.Error())
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	}
+	
+	func rollback(conn *sql.Conn, t* testing.T) {
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		tx, err := conn.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("Error begin tx %s\n", err.Error())
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	
+	func doCrud(conn *sql.Conn, id int, t* testing.T) (bool) {
+	
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	
+		stmt, err := conn.PrepareContext(ctx, "drop table test_failover")
+		if err != nil {

--- a/tests/unittest/testall.sh
+++ b/tests/unittest/testall.sh
@@ -28,4 +28,12 @@ do
     rm -f *.log 
     popd
 done
+
+./govet.sh
+rv=$?
+if [ 0 != $rv ]
+then
+    exit $rv
+fi
+
 exit $overall

--- a/tests/unittest/testutil/vet.log
+++ b/tests/unittest/testutil/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/tests/unittest/testutil
+./setup.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+		}
+		db0.SetMaxIdleConns(0)
+		dbs[ip+dbName] = db0
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		conn0, err := db0.Conn(ctx)
+		if err != nil {
+			return err

--- a/tests/unittest3/oracleHighLoadAdj/cmd/vet.log
+++ b/tests/unittest3/oracleHighLoadAdj/cmd/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/tests/unittest3/oracleHighLoadAdj/cmd
+./rude.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	}
+	
+	func execSQL(conn *sql.Conn, sqlStr string, skipCommit bool) *sql.Tx {
+		ctx, _ := context.WithTimeout(context.Background(), 7*24*3600*time.Second)
+		tx, err := conn.BeginTx(ctx, nil)
+		if err != nil {
+			fmt.Printf("Error startT %s %s\n", sqlStr, err.Error())

--- a/tests/unittest3/oracleHighLoadAdj/vet.log
+++ b/tests/unittest3/oracleHighLoadAdj/vet.log
@@ -1,0 +1,17 @@
+# github.com/paypal/hera/tests/unittest3/oracleHighLoadAdj
+./main_test.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	}
+	
+	func execSql(t *testing.T, conn *sql.Conn, sql string, skipCommit bool) *sql.Tx {
+		ctx, _ := context.WithTimeout(context.Background(), 7*24*3600*time.Second)
+		tx, err := conn.BeginTx(ctx, nil)
+		if err != nil {
+			t.Fatalf("Error startT %s %s\n", sql, err.Error())
+./main_test.go unreachable code
+	func TestBadPassword(t *testing.T) {
+		fmt.Printf("badPass disabled function")
+		return
+		logger.GetLogger().Log(logger.Debug, "TestBadPassword +++++++++++++")
+	
+		retryPasswordLogCnt := testutil.RegexCountFile("Login Retry Attempt...:1", "hera.log")
+		if retryPasswordLogCnt != 1 {

--- a/worker/mysqlworker/vet.log
+++ b/worker/mysqlworker/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/worker/mysqlworker
+./adapter.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	
+	// Checking master status
+	func (adapter *mysqlAdapter) Heartbeat(db *sql.DB) bool {
+		ctx, _ /*cancel*/ := context.WithTimeout(context.Background(), 10*time.Second)
+		writable := false
+		conn, err := db.Conn(ctx)
+		if err != nil {

--- a/worker/oracleworker/vet.log
+++ b/worker/oracleworker/vet.log
@@ -1,0 +1,2 @@
+# runtime/cgo
+xcrun: error: invalid active developer path (/Library/Developer/CommandLineTools), missing xcrun at: /Library/Developer/CommandLineTools/usr/bin/xcrun

--- a/worker/postgresworker/vet.log
+++ b/worker/postgresworker/vet.log
@@ -1,0 +1,9 @@
+# github.com/paypal/hera/worker/postgresworker
+./adapter.go the cancel function returned by context.WithTimeout should be called, not discarded, to avoid a context leak
+	}
+	
+	func (adapter *postgresAdapter) Heartbeat(db *sql.DB) bool {
+		ctx, _ /*cancel*/ := context.WithTimeout(context.Background(), 10*time.Second)
+		writable := false
+		conn, err := db.Conn(ctx)
+		if err != nil {


### PR DESCRIPTION
The go vet tool uses heuristics to detect bad code. This script runs against the source tree and can store "accepted" bad code messages in vet.log