### PR TITLE
restrict shard_key_auto_discovery event to str shard keys

### DIFF
--- a/lib/coordinatorsharding.go
+++ b/lib/coordinatorsharding.go
@@ -425,8 +425,9 @@ func (crd *Coordinator) PreprocessSharding(requests []*netstring.Netstring) (boo
 			logger.GetLogger().Log(logger.Verbose, fmt.Sprintf("shard info auto discovery: key_name=%s, num_values=%d", GetConfig().ShardKeyName, len(crd.shard.shardValues)))
 		}
 
-		if len(crd.shard.shardValues) > 0 {
+		if (len(crd.shard.shardValues) > 0) && GetConfig().ShardKeyValueTypeIsString {
 			// shard_key_auto_discovery
+			// restricting this event to only String type Shard Keys
 			evt := cal.NewCalEvent(EvtTypeSharding, EvtNameShardKeyAutodisc, cal.TransOK, "")
 			evt.AddDataStr("shardkey", GetConfig().ShardKeyName+"|"+crd.shard.shardValues[0])
 			evt.AddDataInt("shardid", int64(crd.shard.shardID))

--- a/tests/functionaltest/sharding_tests/shard_basic/main_test.go
+++ b/tests/functionaltest/sharding_tests/shard_basic/main_test.go
@@ -143,11 +143,13 @@ func TestShardBasic(t *testing.T) {
             t.Fatalf ("Error: No Shard key event for fetch request in CAL");
         }
 	
- 	fmt.Println ("Check CAL log for correct events");
-        cal_count = testutil.RegexCountFile ("SHARDING.*shard_key_auto_discovery.*0.*shardkey=accountid|12346&shardid=3&scuttleid=", "cal.log")
-	if (cal_count < 1) {
-            t.Fatalf ("Error: No shard_key_auto_discovery event seen in CAL");
+ 	fmt.Println("Check log for shard key auto discovery");
+        count = testutil.RegexCount ("shard key auto discovery: shardkey=accountid|12346&shardid=3&scuttleid=")
+	if (count < 1) {
+            t.Fatalf ("Error: Did NOT get shard key auto discovery in log");
         }
+	
+	fmt.Println("Check CAL log for correct events")
         cal_count = testutil.RegexCountFile ("T.*API.*CLIENT_SESSION_3", "cal.log")
 	if (cal_count < 1) {
             t.Fatalf ("Error: Request is not executed by shard 3 as expected");

--- a/tests/functionaltest/sharding_whitelist_tests/no_shard_no_error/main_test.go
+++ b/tests/functionaltest/sharding_whitelist_tests/no_shard_no_error/main_test.go
@@ -134,10 +134,10 @@ func TestNoShardNoError(t *testing.T) {
 	if (count > 0) {
             t.Fatalf ("Error: should NOT get no shard key error");
         }
-	fmt.Println ("Check CAL log for correct events");
-        cal_count := testutil.RegexCountFile ("SHARDING.*shard_key_auto_discovery.*0.*shardkey=accountid|12345&shardid=3&scuttleid=428", "cal.log")
-	if (cal_count < 1) {
-            t.Fatalf ("Error: Did NOT get shard_key_auto_discovery in CAL log");
+	fmt.Println ("Check log for shard key auto discovery");
+        count = testutil.RegexCount ("shard key auto discovery: shardkey=accountid|12345&shardid=3&scuttleid=428")
+	if (count < 1) {
+            t.Fatalf ("Error: Did NOT get shard key auto discovery in log");
         }
 	testutil.DoDefaultValidation(t)
 	logger.GetLogger().Log(logger.Debug, "TestNoShardNoError done  -------------------------------------------------------------")


### PR DESCRIPTION
Removing this event. 
Keeping this event only for String type shard keys would help in debugging issues with #320.