### PR TITLE
restrict shardkey autodisc cal event to str shard keys

### DIFF
--- a/lib/coordinatorsharding.go
+++ b/lib/coordinatorsharding.go
@@ -427,15 +427,30 @@ func (crd *Coordinator) PreprocessSharding(requests []*netstring.Netstring) (boo
 
 		if len(crd.shard.shardValues) > 0 {
 			// shard_key_auto_discovery
-			evt := cal.NewCalEvent(EvtTypeSharding, EvtNameShardKeyAutodisc, cal.TransOK, "")
-			evt.AddDataStr("shardkey", GetConfig().ShardKeyName+"|"+crd.shard.shardValues[0])
-			evt.AddDataInt("shardid", int64(crd.shard.shardID))
-			if len(crd.shard.shardRecs) > 0 {
-				evt.AddDataInt("scuttleid", int64(crd.shard.shardRecs[0].bin))
-				evt.AddDataInt("flags", int64(crd.shard.shardRecs[0].flags))
+			shardkey := GetConfig().ShardKeyName + "|" + crd.shard.shardValues[0]
+			shardid := int64(crd.shard.shardID)
+			shardRecs := crd.shard.shardRecs
+			sqlhash := int64(uint32(crd.sqlhash))
+			if logger.GetLogger().V(logger.Verbose) {
+				logmsg := fmt.Sprintf("shard key auto discovery: shardkey=%s&shardid=%d", shardkey, shardid)
+				if len(shardRecs) > 0 {
+					logmsg += fmt.Sprintf("&scuttleid=%d&flags=%d", int64(shardRecs[0].bin), int64(shardRecs[0].flags))
+				}
+				logmsg += fmt.Sprintf("&sqlhash=%d", sqlhash)
+				logger.GetLogger().Log(logger.Verbose, logmsg)
 			}
-			evt.AddDataInt("sqlhash", int64(uint32(crd.sqlhash)))
-			evt.Completed()
+			// restricting cal event to only String type Shard Keys
+			if GetConfig().ShardKeyValueTypeIsString {
+				evt := cal.NewCalEvent(EvtTypeSharding, EvtNameShardKeyAutodisc, cal.TransOK, "")
+				evt.AddDataStr("shardkey", shardkey)
+				evt.AddDataInt("shardid", shardid)
+				if len(shardRecs) > 0 {
+					evt.AddDataInt("scuttleid", int64(shardRecs[0].bin))
+					evt.AddDataInt("flags", int64(shardRecs[0].flags))
+				}
+				evt.AddDataInt("sqlhash", sqlhash)
+				evt.Completed()
+			}
 		}
 	}
 

--- a/tests/functionaltest/sharding_tests/shard_basic/main_test.go
+++ b/tests/functionaltest/sharding_tests/shard_basic/main_test.go
@@ -143,11 +143,13 @@ func TestShardBasic(t *testing.T) {
             t.Fatalf ("Error: No Shard key event for fetch request in CAL");
         }
 	
- 	fmt.Println ("Check CAL log for correct events");
-        cal_count = testutil.RegexCountFile ("SHARDING.*shard_key_auto_discovery.*0.*shardkey=accountid|12346&shardid=3&scuttleid=", "cal.log")
-	if (cal_count < 1) {
-            t.Fatalf ("Error: No shard_key_auto_discovery event seen in CAL");
+ 	fmt.Println ("Check log for shard key auto discovery");
+        count = testutil.RegexCount ("shard key auto discovery: shardkey=accountid|12346&shardid=3&scuttleid=")
+	if (count < 1) {
+            t.Fatalf ("Error: Did NOT get shard key auto discovery in log");
         }
+	
+	fmt.Println ("Check CAL log for correct events")
         cal_count = testutil.RegexCountFile ("T.*API.*CLIENT_SESSION_3", "cal.log")
 	if (cal_count < 1) {
             t.Fatalf ("Error: Request is not executed by shard 3 as expected");


### PR DESCRIPTION
Replaces PR #383.
Removes shardkey autodisc cal event and replaces it with a verbose log.
Keeping this cal event only for String type shard keys would help in debugging issues with #320.